### PR TITLE
Vote() message fixes

### DIFF
--- a/contracts/atom_wars/Cargo.toml
+++ b/contracts/atom_wars/Cargo.toml
@@ -28,7 +28,6 @@ serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 snafu = { version = "0.6.3" }
 thiserror = { version = "1.0.23" }
 cw-storage-plus = { version = "0.13.2" }
-osmosis-std = "0.21.0"
 cosmwasm-schema = { version = "1.0.0-beta8" }
 
 [dev-dependencies]


### PR DESCRIPTION
- Fixed panic in vote() if lockups end before the round ends
- Checked if the users total voting power is 0, since in that case we don't need to update the stores, and can save some gas
- Removed import of osmosis-std since we are not using it, and building it takes a lot of time