### PR TITLE
Add queries needed for the tribute contract

### DIFF
--- a/contracts/atom_wars/src/query.rs
+++ b/contracts/atom_wars/src/query.rs
@@ -15,6 +15,11 @@ pub enum QueryMsg {
     UserVotingPower {
         address: String,
     },
+    UserVote {
+        round_id: u64,
+        tranche_id: u64,
+        address: String,
+    },
     CurrentRound {},
     RoundEnd {
         round_id: u64,

--- a/contracts/atom_wars/src/state.rs
+++ b/contracts/atom_wars/src/state.rs
@@ -32,6 +32,7 @@ pub struct LockEntry {
 // PROP_MAP: key(round_id, tranche_id, prop_id) -> Proposal {
 //     round_id: u64,
 //     tranche_id: u64,
+//     proposal_id: u64,
 //     covenant_params: String,
 //     executed: bool,
 //     power: Uint128
@@ -41,6 +42,7 @@ pub const PROPOSAL_MAP: Map<(u64, u64, u64), Proposal> = Map::new("prop_map");
 pub struct Proposal {
     pub round_id: u64,
     pub tranche_id: u64,
+    pub proposal_id: u64,
     pub covenant_params: String,
     pub executed: bool, // TODO: maybe remove in the future
     pub power: Uint128,


### PR DESCRIPTION
- Proposal struct is extended with proposal_id field that is needed for tribute contract to determine if user voted for one of N top proposal when they want to claim their portion of tribute
- Added new query UserVote so that tribute can determine what user voted for in the given round_id and tranche_id