### PR TITLE
Bump 3rd party dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,13 @@ codegen-units = 1
 panic = 'abort'
 incremental = false
 overflow-checks = true
+
+[workspace.dependencies]
+cosmwasm-std = "1.4.0"
+schemars = "0.8.15"
+serde = { version = "1.0.188", default-features = false, features = ["derive"] }
+thiserror = { version = "1.0.49" }
+cw-storage-plus = { version = "1.1.0" }
+cw2 = "1.1.1"
+cosmwasm-schema = { version = "1.4.0" }
+proptest = "1.0.0"

--- a/contracts/atom_wars/Cargo.toml
+++ b/contracts/atom_wars/Cargo.toml
@@ -22,15 +22,14 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-beta8", features = ["staking"] }
-schemars = "0.8.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-snafu = { version = "0.6.3" }
-thiserror = { version = "1.0.23" }
-cw-storage-plus = { version = "0.13.2" }
-cw2 = "0.13.4"
-cosmwasm-schema = { version = "1.0.0-beta8" }
+cosmwasm-std = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+cosmwasm-schema = { workspace = true }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta8" }
-proptest = "1.0.0"
+cosmwasm-schema = { workspace = true }
+proptest = { workspace = true }

--- a/contracts/tribute/Cargo.toml
+++ b/contracts/tribute/Cargo.toml
@@ -21,15 +21,14 @@ backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]
-cosmwasm-std = { version = "1.0.0-beta8", features = ["staking"] }
-schemars = "0.8.1"
-serde = { version = "1.0.103", default-features = false, features = ["derive"] }
-snafu = { version = "0.6.3" }
-thiserror = { version = "1.0.23" }
-cw-storage-plus = { version = "0.13.2" }
-cw2 = "0.13.4"
-cosmwasm-schema = { version = "1.0.0-beta8" }
+cosmwasm-std = { workspace = true }
+schemars = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+cw-storage-plus = { workspace = true }
+cw2 = { workspace = true }
+cosmwasm-schema = { workspace = true }
 atom-wars = { path = "../atom_wars" }
 
 [dev-dependencies]
-cosmwasm-schema = { version = "1.0.0-beta8" }
+cosmwasm-schema = { workspace = true }

--- a/contracts/tribute/src/testing.rs
+++ b/contracts/tribute/src/testing.rs
@@ -418,7 +418,7 @@ fn claim_tribute_test() {
             ),
             expected_tribute_claim: 0,
             expected_success: false,
-            expected_error_msg: "Tribute not found".to_string(),
+            expected_error_msg: "not found".to_string(),
         },
     ];
 
@@ -590,7 +590,7 @@ fn refund_tribute_test() {
             tribute_refunder: None,
             expected_tribute_refund: 0,
             expected_success: false,
-            expected_error_msg: "Tribute not found".to_string(),
+            expected_error_msg: "not found".to_string(),
         },
         RefundTributeTestCase {
             description: "try to get refund if not the depositor".to_string(),


### PR DESCRIPTION
- Bumped dependencies versions and consolidated them in the workspace Cargo.toml.
- Removed unused `snafu` dependency.
- An error returned by the cw-storage-plus when no entry under the given key has changed, so I had to update the unit tests as well.