### PR TITLE
Total voting power tracking implementation

### DIFF
--- a/contracts/atom_wars/src/query.rs
+++ b/contracts/atom_wars/src/query.rs
@@ -24,6 +24,9 @@ pub enum QueryMsg {
     RoundEnd {
         round_id: u64,
     },
+    RoundTotalVotingPower {
+        round_id: u64,
+    },
     RoundProposals {
         round_id: u64,
         tranche_id: u64,

--- a/contracts/atom_wars/src/state.rs
+++ b/contracts/atom_wars/src/state.rs
@@ -62,8 +62,11 @@ pub struct Vote {
 // PROPS_BY_SCORE: key((round_id, tranche_id), score, prop_id) -> prop_id
 pub const PROPS_BY_SCORE: Map<((u64, u64), u128, u64), u64> = Map::new("props_by_score");
 
-// TOTAL_POWER_VOTING: key(round_id, tranche_id) -> Uint128
-pub const TOTAL_POWER_VOTING: Map<(u64, u64), Uint128> = Map::new("total_power_voting");
+// TOTAL_VOTED_POWER: key(round_id, tranche_id) -> Uint128
+pub const TOTAL_VOTED_POWER: Map<(u64, u64), Uint128> = Map::new("total_voted_power");
+
+// TOTAL_ROUND_POWER: key(round_id) -> total_round_voting_power
+pub const TOTAL_ROUND_POWER: Map<u64, Uint128> = Map::new("total_round_power");
 
 // TRANCHE_MAP: key(tranche_id) -> Tranche
 pub const TRANCHE_MAP: Map<u64, Tranche> = Map::new("tranche_map");


### PR DESCRIPTION
Closes #10

- Total voting power is now updated each time any user locks or relocks tokens. We first calculate the last round in which user will have voting power > 0, and then update the total voting power for each round starting from the current round until that last round.
- Total voting power information is then used by the "top N proposals" query.
- `compute_current_round_id()` and `compute_round_end()` are modified to accept `Constants` instance instead of `Deps` to make them more gas efficient, since they are now called multiple times during `lock_tokens()` and `refresh_lock_duration()` execution.
- `TOTAL_POWER_VOTING` is renamed to `TOTAL_VOTED_POWER`.