### PR TITLE
Remove total_pool

### DIFF
--- a/contracts/atom_wars/src/contract.rs
+++ b/contracts/atom_wars/src/contract.rs
@@ -53,7 +53,6 @@ pub fn instantiate(
         denom: msg.denom.clone(),
         round_length: msg.round_length,
         lock_epoch_length: msg.lock_epoch_length,
-        total_pool: msg.total_pool,
         first_round_start: msg.first_round_start,
     };
 

--- a/contracts/atom_wars/src/msg.rs
+++ b/contracts/atom_wars/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Timestamp};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -9,7 +9,6 @@ pub struct InstantiateMsg {
     pub denom: String,
     pub round_length: u64,
     pub lock_epoch_length: u64,
-    pub total_pool: Uint128,
     pub tranches: Vec<Tranche>,
     pub first_round_start: Timestamp,
     pub whitelist_admins: Vec<Addr>,

--- a/contracts/atom_wars/src/state.rs
+++ b/contracts/atom_wars/src/state.rs
@@ -9,7 +9,6 @@ pub struct Constants {
     pub denom: String,
     pub round_length: u64,
     pub lock_epoch_length: u64,
-    pub total_pool: Uint128,
     pub first_round_start: Timestamp,
 }
 

--- a/contracts/atom_wars/src/testing.rs
+++ b/contracts/atom_wars/src/testing.rs
@@ -8,7 +8,7 @@ use crate::{
     msg::{ExecuteMsg, InstantiateMsg},
 };
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-use cosmwasm_std::{BankMsg, CosmosMsg, Deps, Timestamp, Uint128};
+use cosmwasm_std::{BankMsg, CosmosMsg, Deps, Timestamp};
 use cosmwasm_std::{Coin, StdError, StdResult};
 use proptest::prelude::*;
 
@@ -23,7 +23,6 @@ pub fn get_default_instantiate_msg() -> InstantiateMsg {
         denom: STATOM.to_string(),
         round_length: TWO_WEEKS_IN_NANO_SECONDS,
         lock_epoch_length: ONE_MONTH_IN_NANO_SECONDS,
-        total_pool: Uint128::zero(),
         tranches: vec![Tranche {
             tranche_id: 1,
             metadata: "tranche 1".to_string(),
@@ -56,7 +55,6 @@ fn instantiate_test() {
     let constants = res.unwrap();
     assert_eq!(msg.denom, constants.denom);
     assert_eq!(msg.round_length, constants.round_length);
-    assert_eq!(msg.total_pool, constants.total_pool);
 }
 
 #[test]


### PR DESCRIPTION
Removed total_pool field from storage and instantiation message since we are not using it.