### PR TITLE
Whitelist admin addresses converted to String in InstantiateMsg

### DIFF
--- a/contracts/atom_wars/src/contract.rs
+++ b/contracts/atom_wars/src/contract.rs
@@ -60,7 +60,12 @@ pub fn instantiate(
     LOCK_ID.save(deps.storage, &0)?;
     PROP_ID.save(deps.storage, &0)?;
 
-    WHITELIST_ADMINS.save(deps.storage, &msg.whitelist_admins)?;
+    let mut whitelist_admins: Vec<Addr> = vec![];
+    for admin in msg.whitelist_admins {
+        whitelist_admins.push(deps.api.addr_validate(&admin)?);
+    }
+
+    WHITELIST_ADMINS.save(deps.storage, &whitelist_admins)?;
     WHITELIST.save(deps.storage, &msg.initial_whitelist)?;
 
     // For each tranche, create a tranche in the TRANCHE_MAP and set the total power to 0

--- a/contracts/atom_wars/src/msg.rs
+++ b/contracts/atom_wars/src/msg.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Addr, Timestamp};
+use cosmwasm_std::Timestamp;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +11,7 @@ pub struct InstantiateMsg {
     pub lock_epoch_length: u64,
     pub tranches: Vec<Tranche>,
     pub first_round_start: Timestamp,
-    pub whitelist_admins: Vec<Addr>,
+    pub whitelist_admins: Vec<String>,
     pub initial_whitelist: Vec<CovenantParams>,
 }
 


### PR DESCRIPTION
Following the [recommendation](https://github.com/DA0-DA0/dao-contracts/wiki/CosmWasm-security-best-practices#dont-deserialize-into-addr), replaced `Addr` with `String` in `whitelist_admins` field.