### PR TITLE
Further simplify funds validation during lock_tokens()

### DIFF
--- a/contracts/atom_wars/src/error.rs
+++ b/contracts/atom_wars/src/error.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{OverflowError, StdError};
+use cw_utils::PaymentError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -10,5 +11,8 @@ pub enum ContractError {
     OverflowError(#[from] OverflowError),
 
     #[error("Unauthorized")]
-    Unauthorized {},
+    Unauthorized,
+
+    #[error("{0}")]
+    PaymentError(#[from] PaymentError),
 }


### PR DESCRIPTION
- must_pay() already checks if exactly one coin of specified denom was sent
- also made error handling a bit more straight-forward