### PR TITLE
Change valset store init to not require the previous round initialized

### DIFF
--- a/contracts/hydro/src/validators_icqs.rs
+++ b/contracts/hydro/src/validators_icqs.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     contract::{compute_current_round_id, NATIVE_TOKEN_DENOM},
     error::ContractError,
-    lsm_integration::{initialize_validator_store_helper, update_scores_due_to_power_ratio_change},
+    lsm_integration::{initialize_validator_store, update_scores_due_to_power_ratio_change},
     state::{
         Constants, ValidatorInfo, CONSTANTS, QUERY_ID_TO_VALIDATOR, VALIDATORS_INFO,
         VALIDATORS_PER_ROUND, VALIDATOR_TO_QUERY_ID,
@@ -123,7 +123,7 @@ pub fn handle_delivered_interchain_query_result(
     };
     let constants = CONSTANTS.load(deps.storage)?;
     let current_round = compute_current_round_id(&env, &constants)?;
-    initialize_validator_store_helper(deps.storage, current_round)?;
+    initialize_validator_store(deps.storage, current_round)?;
 
     let validator_address = validator.operator_address.clone();
     let new_tokens = Uint128::from_str(&validator.tokens)?;


### PR DESCRIPTION
* Makes the old initialization method a helper that is not called directly
* Add a new method that goes backwards to find the latest initialized round, then forwards to initialize the rounds

This should make testing easier, since it is not the case anymore that updates have to come in during every round.
It also has marginal benefits for production, since a full round of inactivity would no longer completely brick the contract.