### PR TITLE
Add query for val power ratio

### DIFF
--- a/contracts/hydro/src/query.rs
+++ b/contracts/hydro/src/query.rs
@@ -1,6 +1,6 @@
 use crate::state::{Constants, LockEntry, Proposal, Tranche, VoteWithPower};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Decimal, Timestamp, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -78,6 +78,9 @@ pub enum QueryMsg {
 
     #[returns(TotalLockedTokensResponse)]
     TotalLockedTokens {},
+
+    #[returns(ValidatorPowerRatioResponse)]
+    ValidatorPowerRatio { validator: String, round_id: u64 },
 }
 
 #[cw_serde]
@@ -162,4 +165,9 @@ pub struct TotalLockedTokensResponse {
 #[cw_serde]
 pub struct RoundProposalsResponse {
     pub proposals: Vec<Proposal>,
+}
+
+#[cw_serde]
+pub struct ValidatorPowerRatioResponse {
+    pub ratio: Decimal,
 }


### PR DESCRIPTION
I did not add a test here because this query goes straight into the get_validator_power_ratio_for_round function, which internal logic that is well tested relies on. lmk if you think it needs a test, but my feeling is it's fine as-is