### PR TITLE
Run interchain tests in nightly GH workflow

### DIFF
--- a/.github/workflows/nigthly-tests.yml
+++ b/.github/workflows/nigthly-tests.yml
@@ -1,0 +1,14 @@
+name: Nightly Tests
+
+on:
+  schedule:
+    # run at 4am every day
+    - cron: '0 4 * * *'
+
+jobs:
+  test-interchain:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Interchain Tests
+      run: make build-docker-relayer && make test-interchain

--- a/test/interchain/hydro_suite.go
+++ b/test/interchain/hydro_suite.go
@@ -223,6 +223,7 @@ func (s *HydroSuite) InstantiateHydroContract(
 		"hub_transfer_channel_id":            neutronTransferChannel.ChannelID,
 		"icq_update_period":                  10,
 		"icq_managers":                       []string{adminAddr},
+		"is_in_pilot_mode":                   false,
 	}
 	initHydroJson, err := json.Marshal(initHydro)
 	s.Require().NoError(err)


### PR DESCRIPTION
Closes #121

Added a separate GH worflow that runs every day at 4am UTC time. This workflow currently runs only interchain tests, since they take ~30 minutes to complete and it wouldn't be efficient to run them on each PR.