### PR TITLE
Add mising types in schema generation

### DIFF
--- a/contracts/hydro/schema/hydro_full_schema.json
+++ b/contracts/hydro/schema/hydro_full_schema.json
@@ -1922,6 +1922,29 @@
       },
       "additionalProperties": false
     },
+    "i_c_q_managers": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ICQManagersResponse",
+      "type": "object",
+      "required": [
+        "managers"
+      ],
+      "properties": {
+        "managers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Addr"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        }
+      }
+    },
     "proposal": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ProposalResponse",
@@ -1990,6 +2013,55 @@
         },
         "Uint128": {
           "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "registered_validator_queries": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "RegisteredValidatorQueriesResponse",
+      "type": "object",
+      "required": [
+        "query_ids"
+      ],
+      "properties": {
+        "query_ids": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "validator_power_ratio": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "ValidatorPowerRatioResponse",
+      "type": "object",
+      "required": [
+        "ratio"
+      ],
+      "properties": {
+        "ratio": {
+          "$ref": "#/definitions/Decimal"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Decimal": {
+          "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
           "type": "string"
         }
       }

--- a/contracts/hydro/schema/i_c_q_managers_response.json
+++ b/contracts/hydro/schema/i_c_q_managers_response.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ICQManagersResponse",
+  "type": "object",
+  "required": [
+    "managers"
+  ],
+  "properties": {
+    "managers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Addr"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/hydro/schema/registered_validator_queries_response.json
+++ b/contracts/hydro/schema/registered_validator_queries_response.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RegisteredValidatorQueriesResponse",
+  "type": "object",
+  "required": [
+    "query_ids"
+  ],
+  "properties": {
+    "query_ids": {
+      "type": "array",
+      "items": {
+        "type": "array",
+        "items": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          }
+        ],
+        "maxItems": 2,
+        "minItems": 2
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/contracts/hydro/schema/validator_power_ratio_response.json
+++ b/contracts/hydro/schema/validator_power_ratio_response.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "ValidatorPowerRatioResponse",
+  "type": "object",
+  "required": [
+    "ratio"
+  ],
+  "properties": {
+    "ratio": {
+      "$ref": "#/definitions/Decimal"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/hydro/src/bin/hydro_schema.rs
+++ b/contracts/hydro/src/bin/hydro_schema.rs
@@ -6,11 +6,11 @@ use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 use hydro::msg::{ExecuteMsg, InstantiateMsg};
 use hydro::query::{
     AllUserLockupsResponse, ConstantsResponse, CurrentRoundResponse, ExpiredUserLockupsResponse,
-    LiquidityDeploymentResponse, ProposalResponse, QueryMsg, RoundEndResponse,
-    RoundProposalsResponse, RoundTotalVotingPowerResponse,
-    RoundTrancheLiquidityDeploymentsResponse, TopNProposalsResponse, TotalLockedTokensResponse,
-    TranchesResponse, UserVotesResponse, UserVotingPowerResponse, WhitelistAdminsResponse,
-    WhitelistResponse,
+    ICQManagersResponse, LiquidityDeploymentResponse, ProposalResponse, QueryMsg,
+    RegisteredValidatorQueriesResponse, RoundEndResponse, RoundProposalsResponse,
+    RoundTotalVotingPowerResponse, RoundTrancheLiquidityDeploymentsResponse, TopNProposalsResponse,
+    TotalLockedTokensResponse, TranchesResponse, UserVotesResponse, UserVotingPowerResponse,
+    ValidatorPowerRatioResponse, WhitelistAdminsResponse, WhitelistResponse,
 };
 
 fn main() {
@@ -43,4 +43,7 @@ fn main() {
         &schema_for!(RoundTrancheLiquidityDeploymentsResponse),
         &out_dir,
     );
+    export_schema(&schema_for!(ICQManagersResponse), &out_dir);
+    export_schema(&schema_for!(RegisteredValidatorQueriesResponse), &out_dir);
+    export_schema(&schema_for!(ValidatorPowerRatioResponse), &out_dir);
 }

--- a/contracts/tribute/schema/historical_tribute_claims_response.json
+++ b/contracts/tribute/schema/historical_tribute_claims_response.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "HistoricalTributeClaimsResponse",
+  "type": "object",
+  "required": [
+    "claims"
+  ],
+  "properties": {
+    "claims": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TributeClaim"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "TributeClaim": {
+      "type": "object",
+      "required": [
+        "amount",
+        "proposal_id",
+        "round_id",
+        "tranche_id",
+        "tribute_id"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Coin"
+        },
+        "proposal_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "round_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "tranche_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "tribute_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/tribute/schema/outstanding_tribute_claims_response.json
+++ b/contracts/tribute/schema/outstanding_tribute_claims_response.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OutstandingTributeClaimsResponse",
+  "type": "object",
+  "required": [
+    "claims"
+  ],
+  "properties": {
+    "claims": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TributeClaim"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "TributeClaim": {
+      "type": "object",
+      "required": [
+        "amount",
+        "proposal_id",
+        "round_id",
+        "tranche_id",
+        "tribute_id"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Coin"
+        },
+        "proposal_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "round_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "tranche_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "tribute_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/tribute/schema/round_tributes_response.json
+++ b/contracts/tribute/schema/round_tributes_response.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "RoundTributesResponse",
+  "type": "object",
+  "required": [
+    "tributes"
+  ],
+  "properties": {
+    "tributes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Tribute"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "Addr": {
+      "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+      "type": "string"
+    },
+    "Coin": {
+      "type": "object",
+      "required": [
+        "amount",
+        "denom"
+      ],
+      "properties": {
+        "amount": {
+          "$ref": "#/definitions/Uint128"
+        },
+        "denom": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "Timestamp": {
+      "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint64"
+        }
+      ]
+    },
+    "Tribute": {
+      "type": "object",
+      "required": [
+        "creation_round",
+        "creation_time",
+        "depositor",
+        "funds",
+        "proposal_id",
+        "refunded",
+        "round_id",
+        "tranche_id",
+        "tribute_id"
+      ],
+      "properties": {
+        "creation_round": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "creation_time": {
+          "$ref": "#/definitions/Timestamp"
+        },
+        "depositor": {
+          "$ref": "#/definitions/Addr"
+        },
+        "funds": {
+          "$ref": "#/definitions/Coin"
+        },
+        "proposal_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "refunded": {
+          "type": "boolean"
+        },
+        "round_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "tranche_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "tribute_id": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "additionalProperties": false
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    },
+    "Uint64": {
+      "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/contracts/tribute/schema/tribute_full_schema.json
+++ b/contracts/tribute/schema/tribute_full_schema.json
@@ -310,6 +310,190 @@
   "migrate": {},
   "sudo": {},
   "responses": {
+    "round_tributes": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "RoundTributesResponse",
+      "type": "object",
+      "required": [
+        "tributes"
+      ],
+      "properties": {
+        "tributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Tribute"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Addr": {
+          "description": "A human readable address.\n\nIn Cosmos, this is typically bech32 encoded. But for multi-chain smart contracts no assumptions should be made other than being UTF-8 encoded and of reasonable length.\n\nThis type represents a validated address. It can be created in the following ways 1. Use `Addr::unchecked(input)` 2. Use `let checked: Addr = deps.api.addr_validate(input)?` 3. Use `let checked: Addr = deps.api.addr_humanize(canonical_addr)?` 4. Deserialize from JSON. This must only be done from JSON that was validated before such as a contract's state. `Addr` must not be used in messages sent by the user because this would result in unvalidated instances.\n\nThis type is immutable. If you really need to mutate it (Really? Are you sure?), create a mutable copy using `let mut mutable = Addr::to_string()` and operate on that `String` instance.",
+          "type": "string"
+        },
+        "Coin": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "Timestamp": {
+          "description": "A point in time in nanosecond precision.\n\nThis type can represent times from 1970-01-01T00:00:00Z to 2554-07-21T23:34:33Z.\n\n## Examples\n\n``` # use cosmwasm_std::Timestamp; let ts = Timestamp::from_nanos(1_000_000_202); assert_eq!(ts.nanos(), 1_000_000_202); assert_eq!(ts.seconds(), 1); assert_eq!(ts.subsec_nanos(), 202);\n\nlet ts = ts.plus_seconds(2); assert_eq!(ts.nanos(), 3_000_000_202); assert_eq!(ts.seconds(), 3); assert_eq!(ts.subsec_nanos(), 202); ```",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Uint64"
+            }
+          ]
+        },
+        "Tribute": {
+          "type": "object",
+          "required": [
+            "creation_round",
+            "creation_time",
+            "depositor",
+            "funds",
+            "proposal_id",
+            "refunded",
+            "round_id",
+            "tranche_id",
+            "tribute_id"
+          ],
+          "properties": {
+            "creation_round": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "creation_time": {
+              "$ref": "#/definitions/Timestamp"
+            },
+            "depositor": {
+              "$ref": "#/definitions/Addr"
+            },
+            "funds": {
+              "$ref": "#/definitions/Coin"
+            },
+            "proposal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "refunded": {
+              "type": "boolean"
+            },
+            "round_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "tranche_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "tribute_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        },
+        "Uint64": {
+          "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "historical_tribute_claims": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "HistoricalTributeClaimsResponse",
+      "type": "object",
+      "required": [
+        "claims"
+      ],
+      "properties": {
+        "claims": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TributeClaim"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Coin": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "TributeClaim": {
+          "type": "object",
+          "required": [
+            "amount",
+            "proposal_id",
+            "round_id",
+            "tranche_id",
+            "tribute_id"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Coin"
+            },
+            "proposal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "round_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "tranche_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "tribute_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
     "config": {
       "$schema": "http://json-schema.org/draft-07/schema#",
       "title": "ConfigResponse",
@@ -447,6 +631,81 @@
         },
         "Uint64": {
           "description": "A thin wrapper around u64 that is using strings for JSON encoding/decoding, such that the full u64 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u64` to get the value out:\n\n``` # use cosmwasm_std::Uint64; let a = Uint64::from(42u64); assert_eq!(a.u64(), 42);\n\nlet b = Uint64::from(70u32); assert_eq!(b.u64(), 70); ```",
+          "type": "string"
+        }
+      }
+    },
+    "outstanding_tribute_claims": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "OutstandingTributeClaimsResponse",
+      "type": "object",
+      "required": [
+        "claims"
+      ],
+      "properties": {
+        "claims": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TributeClaim"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "Coin": {
+          "type": "object",
+          "required": [
+            "amount",
+            "denom"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Uint128"
+            },
+            "denom": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "TributeClaim": {
+          "type": "object",
+          "required": [
+            "amount",
+            "proposal_id",
+            "round_id",
+            "tranche_id",
+            "tribute_id"
+          ],
+          "properties": {
+            "amount": {
+              "$ref": "#/definitions/Coin"
+            },
+            "proposal_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "round_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "tranche_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "tribute_id": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            }
+          },
+          "additionalProperties": false
+        },
+        "Uint128": {
+          "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
           "type": "string"
         }
       }

--- a/contracts/tribute/src/bin/tribute_schema.rs
+++ b/contracts/tribute/src/bin/tribute_schema.rs
@@ -4,7 +4,10 @@ use std::fs::create_dir_all;
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
 use tribute::msg::{ExecuteMsg, InstantiateMsg};
-use tribute::query::{ConfigResponse, ProposalTributesResponse, QueryMsg};
+use tribute::query::{
+    ConfigResponse, HistoricalTributeClaimsResponse, OutstandingTributeClaimsResponse,
+    ProposalTributesResponse, QueryMsg, RoundTributesResponse,
+};
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -18,4 +21,7 @@ fn main() {
 
     export_schema(&schema_for!(ConfigResponse), &out_dir);
     export_schema(&schema_for!(ProposalTributesResponse), &out_dir);
+    export_schema(&schema_for!(HistoricalTributeClaimsResponse), &out_dir);
+    export_schema(&schema_for!(RoundTributesResponse), &out_dir);
+    export_schema(&schema_for!(OutstandingTributeClaimsResponse), &out_dir);
 }

--- a/ts_types/HydroBase.client.ts
+++ b/ts_types/HydroBase.client.ts
@@ -6,7 +6,7 @@
 
 import { CosmWasmClient, SigningCosmWasmClient, ExecuteResult } from "@cosmjs/cosmwasm-stargate";
 import { StdFee } from "@cosmjs/amino";
-import { Uint128, Timestamp, Uint64, AllUserLockupsResponse, LockEntryWithPower, LockEntry, Coin, ConstantsResponse, Constants, CurrentRoundResponse, ExecuteMsg, ProposalToLockups, TrancheInfo, ExpiredUserLockupsResponse, InstantiateMsg, LiquidityDeploymentResponse, LiquidityDeployment, ProposalResponse, Proposal, QueryMsg, RoundEndResponse, RoundProposalsResponse, RoundTotalVotingPowerResponse, RoundTrancheLiquidityDeploymentsResponse, TopNProposalsResponse, TotalLockedTokensResponse, TranchesResponse, Tranche, Decimal, UserVotesResponse, VoteWithPower, UserVotingPowerResponse, Addr, WhitelistAdminsResponse, WhitelistResponse } from "./HydroBase.types";
+import { Uint128, Timestamp, Uint64, AllUserLockupsResponse, LockEntryWithPower, LockEntry, Coin, ConstantsResponse, Constants, CurrentRoundResponse, ExecuteMsg, ProposalToLockups, TrancheInfo, ExpiredUserLockupsResponse, Addr, ICQManagersResponse, InstantiateMsg, LiquidityDeploymentResponse, LiquidityDeployment, ProposalResponse, Proposal, QueryMsg, RegisteredValidatorQueriesResponse, RoundEndResponse, RoundProposalsResponse, RoundTotalVotingPowerResponse, RoundTrancheLiquidityDeploymentsResponse, TopNProposalsResponse, TotalLockedTokensResponse, TranchesResponse, Tranche, Decimal, UserVotesResponse, VoteWithPower, UserVotingPowerResponse, ValidatorPowerRatioResponse, WhitelistAdminsResponse, WhitelistResponse } from "./HydroBase.types";
 export interface HydroBaseReadOnlyInterface {
   contractAddress: string;
   constants: () => Promise<ConstantsResponse>;

--- a/ts_types/HydroBase.types.ts
+++ b/ts_types/HydroBase.types.ts
@@ -138,6 +138,10 @@ export interface TrancheInfo {
 export interface ExpiredUserLockupsResponse {
   lockups: LockEntry[];
 }
+export type Addr = string;
+export interface ICQManagersResponse {
+  managers: Addr[];
+}
 export interface InstantiateMsg {
   first_round_start: Timestamp;
   hub_connection_id: string;
@@ -265,6 +269,9 @@ export type QueryMsg = {
     tranche_id: number;
   };
 };
+export interface RegisteredValidatorQueriesResponse {
+  query_ids: [string, number][];
+}
 export interface RoundEndResponse {
   round_end: Timestamp;
 }
@@ -302,7 +309,9 @@ export interface VoteWithPower {
 export interface UserVotingPowerResponse {
   voting_power: number;
 }
-export type Addr = string;
+export interface ValidatorPowerRatioResponse {
+  ratio: Decimal;
+}
 export interface WhitelistAdminsResponse {
   admins: Addr[];
 }

--- a/ts_types/TributeBase.client.ts
+++ b/ts_types/TributeBase.client.ts
@@ -6,7 +6,7 @@
 
 import { CosmWasmClient, SigningCosmWasmClient, ExecuteResult } from "@cosmjs/cosmwasm-stargate";
 import { StdFee } from "@cosmjs/amino";
-import { Addr, ConfigResponse, Config, ExecuteMsg, InstantiateMsg, Timestamp, Uint64, Uint128, ProposalTributesResponse, Tribute, Coin, QueryMsg } from "./TributeBase.types";
+import { Addr, ConfigResponse, Config, ExecuteMsg, Uint128, HistoricalTributeClaimsResponse, TributeClaim, Coin, InstantiateMsg, OutstandingTributeClaimsResponse, Timestamp, Uint64, ProposalTributesResponse, Tribute, QueryMsg, RoundTributesResponse } from "./TributeBase.types";
 export interface TributeBaseReadOnlyInterface {
   contractAddress: string;
   config: () => Promise<ConfigResponse>;

--- a/ts_types/TributeBase.types.ts
+++ b/ts_types/TributeBase.types.ts
@@ -32,12 +32,29 @@ export type ExecuteMsg = {
     tribute_id: number;
   };
 };
+export type Uint128 = string;
+export interface HistoricalTributeClaimsResponse {
+  claims: TributeClaim[];
+}
+export interface TributeClaim {
+  amount: Coin;
+  proposal_id: number;
+  round_id: number;
+  tranche_id: number;
+  tribute_id: number;
+}
+export interface Coin {
+  amount: Uint128;
+  denom: string;
+}
 export interface InstantiateMsg {
   hydro_contract: string;
 }
+export interface OutstandingTributeClaimsResponse {
+  claims: TributeClaim[];
+}
 export type Timestamp = Uint64;
 export type Uint64 = string;
-export type Uint128 = string;
 export interface ProposalTributesResponse {
   tributes: Tribute[];
 }
@@ -51,10 +68,6 @@ export interface Tribute {
   round_id: number;
   tranche_id: number;
   tribute_id: number;
-}
-export interface Coin {
-  amount: Uint128;
-  denom: string;
 }
 export type QueryMsg = {
   config: {};
@@ -86,3 +99,6 @@ export type QueryMsg = {
     user_address: string;
   };
 };
+export interface RoundTributesResponse {
+  tributes: Tribute[];
+}


### PR DESCRIPTION
## Description

Added response types that we missed earlier. This caused TS client build failures.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] Targeted the correct branch
* [ ] Included the necessary unit tests
* [ ] Added/adjusted the necessary [interchain tests](./test/interchain/)
* [ ] Added a changelog entry in `.changelog`
* [ ] Compiled the contracts by using `make compile` and included content of the *artifacts* directory into the PR
* [ ] Regenerated front-end schema by using `make schema` and included generated files into the PR
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary
* [ ] Confirmed all CI checks have passed
