### PR TITLE
Allow voting with locks whose voted-for-proposal did not receive any funds

### DIFF
--- a/contracts/hydro/src/utils.rs
+++ b/contracts/hydro/src/utils.rs
@@ -16,7 +16,8 @@ use crate::{
     state::{
         Constants, HeightRange, LockEntry, RoundLockPowerSchedule, CONSTANTS,
         EXTRA_LOCKED_TOKENS_CURRENT_USERS, EXTRA_LOCKED_TOKENS_ROUND_TOTAL, HEIGHT_TO_ROUND,
-        LOCKED_TOKENS, LOCKS_MAP, ROUND_TO_HEIGHT_RANGE, SNAPSHOTS_ACTIVATION_HEIGHT, USER_LOCKS,
+        LIQUIDITY_DEPLOYMENTS_MAP, LOCKED_TOKENS, LOCKS_MAP, PROPOSAL_MAP, ROUND_TO_HEIGHT_RANGE,
+        SNAPSHOTS_ACTIVATION_HEIGHT, USER_LOCKS, VOTE_MAP,
     },
 };
 
@@ -551,4 +552,55 @@ pub fn has_nonzero_funds(liquidity_deployment: LiquidityDeployment) -> bool {
             .deployed_funds
             .iter()
             .any(|coin| coin.amount > Uint128::zero())
+}
+
+// Finds the deployment for the last proposal the given lock has voted for.
+// This will return None if there is no deployment for the proposal.
+// It will return an error if the lock has not voted for any proposal,
+// or if the store entry for the proposals deployment cannot be parsed.
+pub fn find_deployment_for_voted_lock(
+    deps: &Deps<NeutronQuery>,
+    current_round_id: u64,
+    tranche_id: u64,
+    lock_voter: &Addr,
+    lock_id: u64,
+) -> Result<Option<LiquidityDeployment>, ContractError> {
+    let mut check_round = current_round_id - 1;
+    loop {
+        if let Some(prev_vote) = VOTE_MAP.may_load(
+            deps.storage,
+            ((check_round, tranche_id), lock_voter.clone(), lock_id),
+        )? {
+            // Found a vote, so get the proposal and its deployment
+            let prev_proposal =
+                PROPOSAL_MAP.load(deps.storage, (check_round, tranche_id, prev_vote.prop_id))?;
+
+            // load the deployment for the prev_proposal
+            return LIQUIDITY_DEPLOYMENTS_MAP
+                .may_load(
+                    deps.storage,
+                    (
+                        prev_proposal.round_id,
+                        prev_proposal.tranche_id,
+                        prev_proposal.proposal_id,
+                    ),
+                )
+                .map_err(|_| {
+                    // if we cannot read the store, there is an error
+                    ContractError::Std(StdError::generic_err(format!(
+                        "Could not read deployment store for proposal {} in tranche {}.",
+                        prev_proposal.proposal_id, prev_proposal.tranche_id
+                    )))
+                });
+        }
+        check_round -= 1;
+
+        // If we reached the beginning of the tranche, there is an error
+        if check_round <= 0 {
+            return Err(ContractError::Std(StdError::generic_err(format!(
+                "Could not find previous vote for lock_id {} in tranche {}.",
+                lock_id, tranche_id,
+            ))));
+        }
+    }
 }

--- a/contracts/hydro/src/utils.rs
+++ b/contracts/hydro/src/utils.rs
@@ -11,6 +11,7 @@ use crate::{
         get_total_power_for_round, get_validator_power_ratio_for_round, initialize_validator_store,
         validate_denom,
     },
+    msg::LiquidityDeployment,
     query::LockEntryWithPower,
     state::{
         Constants, HeightRange, LockEntry, RoundLockPowerSchedule, CONSTANTS,
@@ -542,4 +543,12 @@ pub fn scale_lockup_power(
 pub struct LockingInfo {
     pub lock_in_public_cap: Option<u128>,
     pub lock_in_known_users_cap: Option<u128>,
+}
+
+pub fn has_nonzero_funds(liquidity_deployment: LiquidityDeployment) -> bool {
+    !liquidity_deployment.deployed_funds.is_empty()
+        && liquidity_deployment
+            .deployed_funds
+            .iter()
+            .any(|coin| coin.amount > Uint128::zero())
 }

--- a/contracts/hydro/src/vote.rs
+++ b/contracts/hydro/src/vote.rs
@@ -4,9 +4,11 @@ use crate::lsm_integration::validate_denom;
 use crate::msg::ProposalToLockups;
 use crate::score_keeper::ProposalPowerUpdate;
 use crate::state::{
-    Constants, LockEntry, Vote, LOCKS_MAP, PROPOSAL_MAP, VOTE_MAP, VOTING_ALLOWED_ROUND,
+    Constants, LockEntry, Vote, LIQUIDITY_DEPLOYMENTS_MAP, LOCKS_MAP, PROPOSAL_MAP, VOTE_MAP,
+    VOTING_ALLOWED_ROUND,
 };
 use crate::utils::get_lock_time_weighted_shares;
+use crate::utils::has_nonzero_funds;
 use cosmwasm_std::{Addr, Decimal, DepsMut, Env, SignedDecimal, StdError, Storage, Uint128};
 use neutron_sdk::bindings::query::NeutronQuery;
 use std::collections::{HashMap, HashSet};
@@ -205,10 +207,46 @@ pub fn process_votes(
 
             if let Some(voting_allowed_round) = voting_allowed_round {
                 if voting_allowed_round > context.round_id {
-                    return Err(ContractError::Std(StdError::generic_err(format!(
-                        "Not allowed to vote with lock_id {} in tranche {}. Cannot vote again with this lock_id until round {}.",
-                        lock_id, context.tranche_id, voting_allowed_round
-                    ))));
+                    // Search for votes in previous rounds in this tranche
+                    let mut check_round = voting_allowed_round - 1;
+                    loop {
+                        if let Some(prev_vote) = VOTE_MAP.may_load(
+                            deps.storage,
+                            (
+                                (check_round, context.tranche_id),
+                                context.sender.clone(),
+                                lock_id,
+                            ),
+                        )? {
+                            // Found a vote - check if the proposal has a deployment entered that has non-zero funds
+                            let prev_proposal = PROPOSAL_MAP.load(
+                                deps.storage,
+                                (check_round, context.tranche_id, prev_vote.prop_id),
+                            )?;
+
+                            // load the deployment for the prev_proposal
+                            let deployment = LIQUIDITY_DEPLOYMENTS_MAP.load(
+                                deps.storage,
+                                (
+                                    prev_proposal.round_id,
+                                    prev_proposal.tranche_id,
+                                    prev_proposal.proposal_id,
+                                ),
+                            );
+
+                            // If there is no deployment for this proposal yet, or it has non-zero funds, then should error out
+                            if deployment.is_err() || has_nonzero_funds(deployment.unwrap()) {
+                                return Err(ContractError::Std(StdError::generic_err(format!(
+                                    "Not allowed to vote with lock_id {} in tranche {}. Cannot vote again with this lock_id until round {}.",
+                                    lock_id, context.tranche_id, voting_allowed_round
+                                ))));
+                            }
+
+                            // If the deployment has zero funds, then we can vote again with this lock_id
+                            break;
+                        }
+                        check_round -= 1;
+                    }
                 }
             }
 

--- a/contracts/tribute/src/contract.rs
+++ b/contracts/tribute/src/contract.rs
@@ -6,6 +6,7 @@ use cosmwasm_std::{
 };
 use cw2::set_contract_version;
 use hydro::msg::LiquidityDeployment;
+use hydro::utils::has_nonzero_funds;
 
 use crate::error::ContractError;
 use crate::msg::{ExecuteMsg, InstantiateMsg};
@@ -386,11 +387,7 @@ fn get_proposal_tributes_info(
 
     if let Ok(liquidity_deployment) = liquidity_deployment_res {
         info.had_deployment_entered = true;
-        info.received_nonzero_funds = !liquidity_deployment.deployed_funds.is_empty()
-            && liquidity_deployment
-                .deployed_funds
-                .iter()
-                .any(|coin| coin.amount > Uint128::zero());
+        info.received_nonzero_funds = has_nonzero_funds(liquidity_deployment);
     }
 
     Ok(info)


### PR DESCRIPTION
## Description

Closes: N/A

*Add a description of the changes that this PR introduces and the files that
are the most critical to review.*

This makes it so that if a lock has voted for a long-deployment-duration proposal in a past round,
but that proposal did not end up getting any funds deployed, then the lock can vote again.

This adds:
* logic in process_votes to let locks vote
* logic in enrich_lockups_with_tranche_infos to properly reflect this in the query endpoints
* a unit test to verify the new behaviour

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Targeted the correct branch
* [x] Included the necessary unit tests
* [ ] Added/adjusted the necessary [interchain tests](./test/interchain/)
* [x] Added a changelog entry in `.changelog`
* [x] Compiled the contracts by using `make compile` and included content of the *artifacts* directory into the PR
* [x] Regenerated front-end schema by using `make schema` and included generated files into the PR
* [x] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary
* [x] Confirmed all CI checks have passed
