### PR TITLE
Added GitHub workflow that populates new round in Staging contracts every day

### DIFF
--- a/.github/workflows/populate-staging-contracts.yml
+++ b/.github/workflows/populate-staging-contracts.yml
@@ -1,0 +1,66 @@
+name: Populate Staging Contracts
+
+on:
+  # Temporaray, to test the workflow
+  pull_request:
+  # schedule:
+  #   # run every day at 10:05 AM UTC (new round in Staging contract starts at 10 AM UTC time)
+  #   - cron: '5 10 * * *'
+
+jobs:
+  populate-new-round:
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout Hydro repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      # Download specific neutrond binary and add it to the PATH so it can be used by other scripts
+      - name: Download Neutron chain binary
+        run: |
+          curl -L -o neutrond https://github.com/neutron-org/neutron/releases/download/v5.0.2/neutrond-linux-amd64
+          chmod +x neutrond
+          echo "$(pwd)" >> $GITHUB_PATH
+      
+      # Use mnemonic to restore the wallet that will be used in next steps.
+      # Set Hydro and Tribute Staging contracts addresses as env variables so they can be used by other scripts.
+      - name: Setup
+        env:
+          # The address derived from this mnemonic (neutron1r6rv879netg009eh6ty23v57qrq29afecuehlm)
+          # is in the whitelist of the Staging Hydro contract, which means it can submit proposals.
+          WALLET_MNEMONIC: ${{ secrets.E2E_TESTS_MNEMONIC }}
+        run: |
+          CONFIG_FILE="./tools/deployment/config_mainnet.json"
+          TX_SENDER_WALLET=$(jq -r '.tx_sender_wallet' $CONFIG_FILE)
+
+          echo $WALLET_MNEMONIC | neutrond keys add $TX_SENDER_WALLET --keyring-backend test --recover
+
+          echo "HYDRO_CONTRACT_ADDRESS=neutron1la84jn93j6qv3lmayrc7mvr3zp0vsmxhy9uhqzmnnevhxuev72uspf7da4" >> $GITHUB_ENV
+          echo "TRIBUTE_CONTRACT_ADDRESS=neutron1e90z4vpxufxvskz3fc80wrz0g57xg4u7zda7dsuwnwm5jp7635dsrt9r4t" >> $GITHUB_ENV
+      
+      # Enter liquidity deployments info for all proposals from the previous round.
+      # If the proposal power was > 0, liquidity deployment info will be entered with deployed_funds > 0.
+      - name: Enter liquidity deployments for previous round
+        run: |
+          CONFIG_FILE="./tools/deployment/config_mainnet.json"
+
+          chmod +x ./tools/deployment/enter_staging_liquidity_deployments.sh
+          chmod +x ./tools/deployment/add_liquidity_deployments.sh
+
+          source ./tools/deployment/enter_staging_liquidity_deployments.sh $CONFIG_FILE $HYDRO_CONTRACT_ADDRESS
+      
+      # Run the script to create proposals with tributes in current round
+      - name: Populate round with proposals and tributes
+        run: |
+          CONFIG_FILE="./tools/deployment/config_mainnet.json"
+
+          chmod +x ./tools/deployment/populate_contracts.sh
+          source ./tools/deployment/populate_contracts.sh $CONFIG_FILE $HYDRO_CONTRACT_ADDRESS $TRIBUTE_CONTRACT_ADDRESS
+      
+      # Refresh some expired lockup or create a new one, and then vote with it in all tranches of the current round
+      - name: Lock tokens and vote
+        run: |
+          CONFIG_FILE="./tools/deployment/config_mainnet.json"
+
+          chmod +x ./tools/deployment/lock_and_vote.sh
+          source ./tools/deployment/lock_and_vote.sh $CONFIG_FILE $HYDRO_CONTRACT_ADDRESS

--- a/.github/workflows/populate-staging-contracts.yml
+++ b/.github/workflows/populate-staging-contracts.yml
@@ -1,11 +1,9 @@
 name: Populate Staging Contracts
 
 on:
-  # Temporaray, to test the workflow
-  pull_request:
-  # schedule:
-  #   # run every day at 10:05 AM UTC (new round in Staging contract starts at 10 AM UTC time)
-  #   - cron: '5 10 * * *'
+  schedule:
+    # run every day at 10:05 AM UTC (new round in Staging contract starts at 10 AM UTC time)
+    - cron: '5 10 * * *'
 
 jobs:
   populate-new-round:

--- a/.github/workflows/populate-staging-contracts.yml
+++ b/.github/workflows/populate-staging-contracts.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           # The address derived from this mnemonic (neutron1r6rv879netg009eh6ty23v57qrq29afecuehlm)
           # is in the whitelist of the Staging Hydro contract, which means it can submit proposals.
-          WALLET_MNEMONIC: ${{ secrets.E2E_TESTS_MNEMONIC }}
+          WALLET_MNEMONIC: ${{ secrets.HYDRO_TEST_MNEMONIC }}
         run: |
           CONFIG_FILE="./tools/deployment/config_mainnet.json"
           TX_SENDER_WALLET=$(jq -r '.tx_sender_wallet' $CONFIG_FILE)

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -47,7 +47,7 @@ To make rewards claimable, liquidity deployments need to be added.
 For a certain proposal in a certain round and certain tranche, here is how you can add a liquidity deployment for it, to make tributes claimable or refundable:
 
 ```bash
-docker run hydro-docker ./tools/deployment/add_liquidity_deployments.sh "./tools/deployment/config_mainnet.json" $HYDRO_CONTRACT_ADDRESS $TRIBUTE_CONTRACT_ADDRESS $ROUND_ID $TRANCHE_ID $PROPOSAL_ID $FUNDS
+docker run hydro-docker ./tools/deployment/add_liquidity_deployments.sh "./tools/deployment/config_mainnet.json" $HYDRO_CONTRACT_ADDRESS $ROUND_ID $TRANCHE_ID $PROPOSAL_ID $FUNDS
 ```
 FUNDS should be 0 if the tribute for the bid should become refundable; and non-zero if it should become claimable.
 Don't worry about the non-zero number - this script isn't actually sending funds over. It only matters whether the number is zero or not.

--- a/tools/deployment/add_liquidity_deployments.sh
+++ b/tools/deployment/add_liquidity_deployments.sh
@@ -2,27 +2,21 @@
 set -eux
 
 # Check for required arguments
-if [ $# -lt 7 ]; then
-  echo "Usage: $0 <config_file> <hydro_contract_address> <tribute_contract_address> <round_id> <tranche_id> <proposal_id> <deployed_fund_amount>"
+if [ $# -lt 6 ]; then
+  echo "Usage: $0 <config_file> <hydro_contract_address> <round_id> <tranche_id> <proposal_id> <deployed_fund_amount>"
   exit 1
 fi
 
 CONFIG_FILE="$1"
 HYDRO_CONTRACT_ADDRESS="$2"
-TRIBUTE_CONTRACT_ADDRESS="$3"
-ROUND_ID="$4"
-TRANCHE_ID="$5"
-PROPOSAL_ID="$6"
-DEPLOYED_FUND_AMOUNT="$7"
-
+ROUND_ID="$3"
+TRANCHE_ID="$4"
+PROPOSAL_ID="$5"
+DEPLOYED_FUND_AMOUNT="$6"
 
 NEUTRON_CHAIN_ID=$(jq -r '.chain_id' $CONFIG_FILE)
 NEUTRON_NODE=$(jq -r '.neutron_rpc_node' $CONFIG_FILE)
 TX_SENDER_WALLET=$(jq -r '.tx_sender_wallet' $CONFIG_FILE)
-
-TRIBUTE_TOKEN_1=$(jq -r '.tribute_token_1' $CONFIG_FILE)
-TRIBUTE_TOKEN_2=$(jq -r '.tribute_token_2' $CONFIG_FILE)
-TRIBUTE_TOKEN_3=$(jq -r '.tribute_token_3' $CONFIG_FILE)
 
 NEUTRON_BINARY="neutrond"
 NEUTRON_CHAIN_ID_FLAG="--chain-id $NEUTRON_CHAIN_ID"

--- a/tools/deployment/config_mainnet.json
+++ b/tools/deployment/config_mainnet.json
@@ -1,14 +1,14 @@
 {
     "chain_id": "neutron-1",
-    "neutron_rpc_node": "https://neutron-rpc.polkachu.com",
+    "neutron_rpc_node": "https://rpc-pulsarix.neutron-1.neutron.org",
     "neutron_api_node": "https://neutron-rest.publicnode.com",
     "hub_rpc_node": "https://cosmos-rpc.publicnode.com:443",
     "hub_api_node": "https://api.cosmos.nodestake.org",
     "tx_sender_wallet": "submitter",
-    "tx_sender_address": "neutron1r6rv879netg009eh6ty23v57qrq29afecuehlm",
     "hub_connection_id": "connection-0",
     "hub_channel_id": "channel-1",
     "tribute_token_1": "untrn",
     "tribute_token_2": "ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9",
-    "tribute_token_3": "ibc/B559A80D62249C8AA07A380E2A2BEA6E5CA9A6F079C912C3A9E9B494105E4F81"
+    "tribute_token_3": "ibc/B559A80D62249C8AA07A380E2A2BEA6E5CA9A6F079C912C3A9E9B494105E4F81",
+    "token_to_lock_1": "ibc/83311BD1F53AEBA1D1D4AE3F505606985E5F2A98C974FE064DC694A569B63F06"
 }

--- a/tools/deployment/config_testnet.json
+++ b/tools/deployment/config_testnet.json
@@ -5,7 +5,6 @@
     "hub_rpc_node": "https://rpc-rs.cosmos.nodestake.top:443",
     "hub_api_node": "https://api-rs.cosmos.nodestake.top:443",
     "tx_sender_wallet": "submitter",
-    "tx_sender_address": "neutron1r6rv879netg009eh6ty23v57qrq29afecuehlm",
     "hub_connection_id": "connection-42",
     "hub_channel_id": "channel-96",
     "tribute_token_1": "untrn",

--- a/tools/deployment/enter_staging_liquidity_deployments.sh
+++ b/tools/deployment/enter_staging_liquidity_deployments.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -ux
+
+CONFIG_FILE="$1"
+HYDRO_CONTRACT_ADDRESS="$2"
+
+NEUTRON_CHAIN_ID=$(jq -r '.chain_id' $CONFIG_FILE)
+NEUTRON_NODE=$(jq -r '.neutron_rpc_node' $CONFIG_FILE)
+TX_SENDER_WALLET=$(jq -r '.tx_sender_wallet' $CONFIG_FILE)
+TX_SENDER_ADDRESS=$(neutrond keys show $TX_SENDER_WALLET --keyring-backend test | grep "address:" | sed 's/.*address: //')
+
+NEUTRON_BINARY="neutrond"
+NEUTRON_CHAIN_ID_FLAG="--chain-id $NEUTRON_CHAIN_ID"
+KEYRING_TEST_FLAG="--keyring-backend test"
+TX_FLAG="--gas auto --gas-adjustment 1.3"
+NEUTRON_NODE_FLAG="--node $NEUTRON_NODE"
+NEUTRON_TX_FLAGS="$TX_FLAG --gas-prices 0.0053untrn --chain-id $NEUTRON_CHAIN_ID $NEUTRON_NODE_FLAG $KEYRING_TEST_FLAG -y"
+
+NON_ZERO_FUNDS=1000
+
+# Goes through all proposals of the given round and tranche and sends txs to enter liqudity deployment information.
+# If the proposal got zero power, deployment info will contain zero funds. Otherwise, funds are set to NON_ZERO_FUNDS
+enter_liquidity_deployments() {
+    ROUND_ID="$1"
+    TRANCHE_ID="$2"
+
+    # Query all (round, tranche) liquidity deployment infos
+    QUERY='{"round_tranche_liquidity_deployments":{"round_id": '$ROUND_ID', "tranche_id": '$TRANCHE_ID', "start_from":0, "limit": 100}}'
+    $NEUTRON_BINARY q wasm contract-state smart $HYDRO_CONTRACT_ADDRESS "$QUERY" $NEUTRON_NODE_FLAG -o json > ./query_res.json
+
+    # Safety check if the liquidity deployment infos are already entered. It is assumed that information
+    # isn't entered partialy (e.g. only for some proposals).
+    if [ "$(jq '.data.liquidity_deployments | length' query_res.json)" -ne 0 ]; then
+        echo "Liquidity deployment infos are already entered for round: '$ROUND_ID' and tranche: '$TRANCHE_ID'"
+        return 0
+    fi
+
+    # Query all round proposals
+    QUERY='{"round_proposals":{"round_id": '$ROUND_ID', "tranche_id": '$TRANCHE_ID', "start_from":0, "limit": 100}}'
+    $NEUTRON_BINARY q wasm contract-state smart $HYDRO_CONTRACT_ADDRESS "$QUERY" $NEUTRON_NODE_FLAG -o json > ./query_res.json
+
+    # Safety check in case there are no proposals
+    if [ "$(jq '.data.proposals | length' query_res.json)" -eq 0 ]; then
+        echo "No proposals found in round: '$ROUND_ID' and tranche: '$TRANCHE_ID'"
+        return 0
+    fi
+
+    PROPOSALS=$(jq -c '[.data.proposals[] | {proposal_id: .proposal_id, power: .power }]' query_res.json)
+
+    # Go through all proposals and enter liquidity deployment info
+    echo "$PROPOSALS" | jq -c '.[]' | while IFS= read -r proposal; do
+        PROPOSAL_ID=$(echo "$proposal" | jq -r '.proposal_id')
+        PROPOSAL_POWER=$(echo "$proposal" | jq -r '.power')
+
+        if [ "$PROPOSAL_POWER" = "0" ]; then
+            FUNDS=0
+        else
+            FUNDS=$NON_ZERO_FUNDS
+        fi
+
+        source ./tools/deployment/add_liquidity_deployments.sh $CONFIG_FILE $HYDRO_CONTRACT_ADDRESS \
+            $ROUND_ID $TRANCHE_ID $PROPOSAL_ID $FUNDS
+    done
+}
+
+query_previous_round() {
+    QUERY='{"current_round": {}}'
+    $NEUTRON_BINARY q wasm contract-state smart $HYDRO_CONTRACT_ADDRESS "$QUERY" $NEUTRON_NODE_FLAG -o json > ./query_res.json
+
+    ROUND_ID=$(jq '.data.round_id' query_res.json)
+    PREVIOUS_ROUND_ID=$((ROUND_ID - 1))
+}
+
+query_previous_round
+
+if [ "$PREVIOUS_ROUND_ID" -eq -1 ]; then
+    echo "Cannot add liquidity deployments for previous round. First round is still in progress."
+    return 0
+fi
+
+TRANCHE_ID=1
+enter_liquidity_deployments $PREVIOUS_ROUND_ID $TRANCHE_ID
+
+TRANCHE_ID=2
+enter_liquidity_deployments $PREVIOUS_ROUND_ID $TRANCHE_ID

--- a/tools/deployment/enter_staging_liquidity_deployments.sh
+++ b/tools/deployment/enter_staging_liquidity_deployments.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ux
+set -eux
 
 CONFIG_FILE="$1"
 HYDRO_CONTRACT_ADDRESS="$2"

--- a/tools/deployment/lock_and_vote.sh
+++ b/tools/deployment/lock_and_vote.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -eux
+
+CONFIG_FILE="$1"
+HYDRO_CONTRACT_ADDRESS="$2"
+
+NEUTRON_CHAIN_ID=$(jq -r '.chain_id' $CONFIG_FILE)
+NEUTRON_NODE=$(jq -r '.neutron_rpc_node' $CONFIG_FILE)
+TX_SENDER_WALLET=$(jq -r '.tx_sender_wallet' $CONFIG_FILE)
+TOKEN_TO_LOCK_1=$(jq -r '.token_to_lock_1' $CONFIG_FILE)
+TX_SENDER_ADDRESS=$(neutrond keys show $TX_SENDER_WALLET --keyring-backend test | grep "address:" | sed 's/.*address: //')
+
+NEUTRON_BINARY="neutrond"
+NEUTRON_CHAIN_ID_FLAG="--chain-id $NEUTRON_CHAIN_ID"
+KEYRING_TEST_FLAG="--keyring-backend test"
+TX_FLAG="--gas auto --gas-adjustment 1.3"
+NEUTRON_NODE_FLAG="--node $NEUTRON_NODE"
+NEUTRON_TX_FLAGS="$TX_FLAG --gas-prices 0.0053untrn --chain-id $NEUTRON_CHAIN_ID $NEUTRON_NODE_FLAG $KEYRING_TEST_FLAG -y"
+
+# Queries expired user lockups. If there is any, it will be refreshed for another lock epoch length.
+# If there are no expired user lockups, a new lockup will be created.
+prepare_lockup_for_voting() {
+    error_handler() {
+        echo "Content of execute_res.json:"
+        cat ./execute_res.json
+    }
+    trap error_handler ERR
+
+    # Query Constants to get the lock epoch length
+    QUERY='{"constants":{ }}'
+    $NEUTRON_BINARY q wasm contract-state smart $HYDRO_CONTRACT_ADDRESS "$QUERY" $NEUTRON_NODE_FLAG -o json > ./query_res.json
+    LOCK_EPOCH_LENGTH=$(jq '.data.constants.lock_epoch_length' query_res.json)
+
+    # Query expired user lockups to see if there are some that can be refreshed
+    QUERY='{"expired_user_lockups":{"address": "'$TX_SENDER_ADDRESS'", "start_from":0, "limit": 100}}'
+    $NEUTRON_BINARY q wasm contract-state smart $HYDRO_CONTRACT_ADDRESS "$QUERY" $NEUTRON_NODE_FLAG -o json > ./query_res.json
+
+    if [ "$(jq '.data.lockups | length' query_res.json)" -eq 0 ]; then
+        LOCK_ID="-1"        
+    else
+        LOCK_ID=$(jq '.data.lockups[0].lock_id' query_res.json)
+    fi
+
+    if [ "$LOCK_ID" -eq -1 ]; then
+        # If there are no expired lockups- create a new one
+        echo 'Creating new lockup ...'
+
+        EXECUTE='{"lock_tokens": {"lock_duration": '$LOCK_EPOCH_LENGTH' }}'
+        echo $EXECUTE
+        $NEUTRON_BINARY tx wasm execute $HYDRO_CONTRACT_ADDRESS "$EXECUTE" --amount 10$TOKEN_TO_LOCK_1 --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS -o json > ./execute_res.json
+        sleep 10
+
+        echo $(extract_new_lock_id)
+
+        read LOCK_ID <<< "$(extract_new_lock_id)"
+    else
+        # If there is some expired lockup- refresh it
+        echo 'Refreshing lockup with ID: '$LOCK_ID' ...'
+
+        EXECUTE='{"refresh_lock_duration": {"lock_ids": ['$LOCK_ID'], "lock_duration": '$LOCK_EPOCH_LENGTH' }}'
+        $NEUTRON_BINARY tx wasm execute $HYDRO_CONTRACT_ADDRESS "$EXECUTE" --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS -o json > ./execute_res.json
+        sleep 10
+    fi
+
+    QUERY='{"current_round": {}}'
+    $NEUTRON_BINARY q wasm contract-state smart $HYDRO_CONTRACT_ADDRESS "$QUERY" $NEUTRON_NODE_FLAG -o json > ./query_res.json
+
+    ROUND_ID=$(jq '.data.round_id' query_res.json)
+}
+
+extract_new_lock_id() {
+    # Extract the txhash from the command result
+    TX_HASH=$(jq -r '.txhash' ./execute_res.json)
+
+    # Query the transaction details using the extracted TX_HASH
+    $NEUTRON_BINARY q tx "$TX_HASH" $NEUTRON_NODE_FLAG -o json &> ./execute_tx.json 
+
+    # Extract the lock_id attribute from the wasm event
+    LOCK_ID=$(jq -r '.events[] | select(.type == "wasm") | .attributes[] | select(.key == "lock_id") | .value' ./execute_tx.json)
+
+    # Echo the LOCK_ID so that it can be captured by the caller
+    echo "$LOCK_ID"
+}
+
+# Use the provided LOCK_ID to vote for the first proposal in the given (ROUND_ID, TRANCHE_ID).
+vote() {
+    ROUND_ID="$1"
+    TRANCHE_ID="$2"
+    LOCK_ID="$3"
+
+    # Query all round proposals
+    QUERY='{"round_proposals":{"round_id": '$ROUND_ID', "tranche_id": '$TRANCHE_ID', "start_from":0, "limit": 100}}'
+    $NEUTRON_BINARY q wasm contract-state smart $HYDRO_CONTRACT_ADDRESS "$QUERY" $NEUTRON_NODE_FLAG -o json > ./query_res.json
+
+    # Safety check in case there are no proposals
+    if [ "$(jq '.data.proposals | length' query_res.json)" -eq 0 ]; then
+        echo "No proposals that can be voted on in round: '$ROUND_ID' and tranche: '$TRANCHE_ID'"
+        return 0
+    fi
+
+    # Take the first proposal ID and vote for it
+    PROPOSAL_ID=$(jq '.data.proposals[0].proposal_id' query_res.json)
+    EXECUTE='{"vote": {"tranche_id": '$TRANCHE_ID', "proposals_votes": [{"proposal_id": '$PROPOSAL_ID', "lock_ids": ['$LOCK_ID']}] }}'
+    $NEUTRON_BINARY tx wasm execute $HYDRO_CONTRACT_ADDRESS "$EXECUTE" --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS -o json > ./execute_res.json
+    sleep 10
+}
+
+prepare_lockup_for_voting
+
+TRANCHE_ID=1
+vote $ROUND_ID $TRANCHE_ID $LOCK_ID
+
+TRANCHE_ID=2
+vote $ROUND_ID $TRANCHE_ID $LOCK_ID

--- a/tools/deployment/populate_contracts.sh
+++ b/tools/deployment/populate_contracts.sh
@@ -20,6 +20,7 @@ TX_FLAG="--gas auto --gas-adjustment 1.3"
 NEUTRON_NODE_FLAG="--node $NEUTRON_NODE"
 NEUTRON_TX_FLAGS="$TX_FLAG --gas-prices 0.0053untrn --chain-id $NEUTRON_CHAIN_ID $NEUTRON_NODE_FLAG $KEYRING_TEST_FLAG -y"
 
+# Creates 3 proposals in the provided tranche
 submit_proposals() {
     error_handler() {
         echo "Content of execute_res.json:"
@@ -27,9 +28,10 @@ submit_proposals() {
     }
     trap error_handler ERR
 
-    echo 'Submitting proposal 1...'
+    TRANCHE_ID="$1"
+    echo 'Submitting first proposal in tranche '$TRANCHE_ID'...'
 
-    EXECUTE='{"create_proposal": {"tranche_id": 1,"title": "Proposal 1 Title", "description": "Proposal 1 Description", "deployment_duration": 1,"minimum_atom_liquidity_request":"1000"}}'
+    EXECUTE='{"create_proposal": {"tranche_id": '$TRANCHE_ID',"title": "Tranche '$TRANCHE_ID' Proposal 1 Title", "description": "Tranche '$TRANCHE_ID' Proposal 1 Description", "deployment_duration": 1,"minimum_atom_liquidity_request":"1000"}}'
     $NEUTRON_BINARY tx wasm execute $HYDRO_CONTRACT_ADDRESS "$EXECUTE" --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS -o json > ./execute_res.json
     sleep 10
 
@@ -38,17 +40,17 @@ submit_proposals() {
 
     read PROPOSAL_ID_1 ROUND_ID_1 <<< "$(extract_proposal_details)"
 
-    echo 'Submitting proposal 2...'
+    echo 'Submitting second proposal in tranche '$TRANCHE_ID'...'
 
-    EXECUTE='{"create_proposal": {"tranche_id": 1,"title": "Proposal 2 Title", "description": "Proposal 2 Description", "deployment_duration": 2,"minimum_atom_liquidity_request":"2000"}}'
+    EXECUTE='{"create_proposal": {"tranche_id": '$TRANCHE_ID',"title": "Tranche '$TRANCHE_ID' Proposal 2 Title", "description": "Tranche '$TRANCHE_ID' Proposal 2 Description", "deployment_duration": 2,"minimum_atom_liquidity_request":"2000"}}'
     $NEUTRON_BINARY tx wasm execute $HYDRO_CONTRACT_ADDRESS "$EXECUTE" --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS -o json > ./execute_res.json
     sleep 10
 
     read PROPOSAL_ID_2 ROUND_ID_2 <<< "$(extract_proposal_details)"
 
-    echo 'Submitting proposal 3...'
+    echo 'Submitting third proposal in tranche '$TRANCHE_ID'...'
 
-    EXECUTE='{"create_proposal": {"tranche_id": 1,"title": "Proposal 3 Title", "description": "Proposal 3 Description", "deployment_duration": 3,"minimum_atom_liquidity_request":"3000"}}'
+    EXECUTE='{"create_proposal": {"tranche_id": '$TRANCHE_ID',"title": "Tranche '$TRANCHE_ID' Proposal 3 Title", "description": "Tranche '$TRANCHE_ID' Proposal 3 Description", "deployment_duration": 3,"minimum_atom_liquidity_request":"3000"}}'
     $NEUTRON_BINARY tx wasm execute $HYDRO_CONTRACT_ADDRESS "$EXECUTE" --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS -o json > ./execute_res.json
     sleep 10
 
@@ -56,26 +58,31 @@ submit_proposals() {
 
 }
 
+# Adds 2 tributes to first proposal in tranche, and 1 tribute to second proposal.
+# Third proposal in tranche is left without any tributes.
 add_tributes() {
-    echo 'Adding proposal 1 tribute...'
+    TRANCHE_ID="$1"
 
-    EXECUTE='{"add_tribute":{"round_id":'"$ROUND_ID_1"',"tranche_id":1,"proposal_id":'"$PROPOSAL_ID_1"'}}'
+    echo 'Adding tribute for the first proposal in tranche '$TRANCHE_ID'...'
+
+    EXECUTE='{"add_tribute":{"round_id":'"$ROUND_ID_1"',"tranche_id":'$TRANCHE_ID',"proposal_id":'"$PROPOSAL_ID_1"'}}'
     $NEUTRON_BINARY tx wasm execute $TRIBUTE_CONTRACT_ADDRESS "$EXECUTE" --amount 10$TRIBUTE_TOKEN_1 --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS
     sleep 10
 
-    echo 'Adding proposal 2 tribute...'
+    echo 'Adding second tribute for the first proposal in tranche '$TRANCHE_ID'...'
 
-    EXECUTE='{"add_tribute":{"round_id":'"$ROUND_ID_2"',"tranche_id":1,"proposal_id":'"$PROPOSAL_ID_2"'}}'
+    EXECUTE='{"add_tribute":{"round_id":'"$ROUND_ID_2"',"tranche_id":'$TRANCHE_ID',"proposal_id":'"$PROPOSAL_ID_1"'}}'
     $NEUTRON_BINARY tx wasm execute $TRIBUTE_CONTRACT_ADDRESS "$EXECUTE" --amount 10$TRIBUTE_TOKEN_2 --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS
     sleep 10
 
-    echo 'Adding proposal 3 tribute...'
+    echo 'Adding tribute for the second proposal in tranche '$TRANCHE_ID'...'
 
-    EXECUTE='{"add_tribute":{"round_id":'"$ROUND_ID_3"',"tranche_id":1,"proposal_id":'"$PROPOSAL_ID_3"'}}'
+    EXECUTE='{"add_tribute":{"round_id":'"$ROUND_ID_3"',"tranche_id":'$TRANCHE_ID',"proposal_id":'"$PROPOSAL_ID_2"'}}'
     $NEUTRON_BINARY tx wasm execute $TRIBUTE_CONTRACT_ADDRESS "$EXECUTE" --amount 10$TRIBUTE_TOKEN_3 --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS
     sleep 10
 }
 
+# Extracts proposal ID and the curent round ID
 extract_proposal_details() {
     # Extract the txhash from the command result
     TX_HASH=$(jq -r '.txhash' ./execute_res.json)
@@ -92,8 +99,12 @@ extract_proposal_details() {
     echo "$PROPOSAL_ID $ROUND_ID"
 }
 
+TRANCHE_ID="1"
+submit_proposals $TRANCHE_ID
+add_tributes $TRANCHE_ID
 
-submit_proposals
-add_tributes
+TRANCHE_ID="2"
+submit_proposals $TRANCHE_ID
+add_tributes $TRANCHE_ID
 
 echo 'Successfully created proposals and tributes'

--- a/tools/deployment/store_instantiate.sh
+++ b/tools/deployment/store_instantiate.sh
@@ -8,6 +8,7 @@ NEUTRON_CHAIN_ID=$(jq -r '.chain_id' $CONFIG_FILE)
 NEUTRON_NODE=$(jq -r '.neutron_rpc_node' $CONFIG_FILE)
 TX_SENDER_WALLET=$(jq -r '.tx_sender_wallet' $CONFIG_FILE)
 TX_SENDER_ADDRESS=$(neutrond keys show $TX_SENDER_WALLET --keyring-backend test | grep "address:" | sed 's/.*address: //')
+HYDRO_TEST_ADDRESS="neutron1r6rv879netg009eh6ty23v57qrq29afecuehlm"
 HUB_CONNECTION_ID=$(jq -r '.hub_connection_id' $CONFIG_FILE)
 HUB_CHANNEL_ID=$(jq -r '.hub_channel_id' $CONFIG_FILE)
 
@@ -35,7 +36,6 @@ ROUND_LENGTH=$ROUND_END_TEST_ROUND_LENGTH
 FIRST_ROUND_START_TIME=$CURRENT_TIME_NO_MINS_AND_SECS
 HYDRO_COMMITTEE_DAODAO="neutron1xd6z4nwmfeamv089fr9s4hlp3vq00l0tn9j9ysauc2j5pcmlm6vsk7nf7q"
 
-IS_IN_PILOT_MODE=true
 MAX_DEPLOYMENT_DURATION=3
 HYDRO_WASM_PATH="./artifacts/hydro.wasm"
 TRIBUTE_WASM_PATH="./artifacts/tribute.wasm"
@@ -108,7 +108,7 @@ instantiate_hydro() {
 
     echo 'Instantiating Hydro contract...'
 
-    INIT_HYDRO='{"round_length":'$ROUND_LENGTH',"lock_epoch_length":'$ROUND_LENGTH', "tranches":[{"name": "ATOM Bucket", "metadata": "A bucket of ATOM to deploy as PoL"}],"first_round_start":"'$FIRST_ROUND_START_TIME'","max_locked_tokens":"20000000000","whitelist_admins":["'$HYDRO_COMMITTEE_DAODAO'","'$TX_SENDER_ADDRESS'"],"initial_whitelist":["'$TX_SENDER_ADDRESS'"],"max_validator_shares_participating":500,"hub_connection_id":"'$HUB_CONNECTION_ID'","hub_transfer_channel_id":"'$HUB_CHANNEL_ID'","icq_update_period":109000,"icq_managers":["'$TX_SENDER_ADDRESS'"],"round_lock_power_schedule": [[1, "1"], [2, "1.25"], [3, "1.5"], [6, "2"], [12, "4"]],"max_deployment_duration":'$MAX_DEPLOYMENT_DURATION'}'
+    INIT_HYDRO='{"round_length":'$ROUND_LENGTH',"lock_epoch_length":'$ROUND_LENGTH', "tranches":[{"name": "ATOM Bucket", "metadata": "A bucket of ATOM to deploy as PoL"}, {"name": "USDC Bucket", "metadata": "This is a bucket for USDC from the Cosmos Hub community pool."}],"first_round_start":"'$FIRST_ROUND_START_TIME'","max_locked_tokens":"20000000000","whitelist_admins":["'$HYDRO_COMMITTEE_DAODAO'","'$TX_SENDER_ADDRESS'","'$HYDRO_TEST_ADDRESS'"],"initial_whitelist":["'$HYDRO_COMMITTEE_DAODAO'","'$TX_SENDER_ADDRESS'","'$HYDRO_TEST_ADDRESS'"],"max_validator_shares_participating":500,"hub_connection_id":"'$HUB_CONNECTION_ID'","hub_transfer_channel_id":"'$HUB_CHANNEL_ID'","icq_update_period":109000,"icq_managers":["'$TX_SENDER_ADDRESS'"],"round_lock_power_schedule": [[1, "1"], [2, "1.25"], [3, "1.5"], [6, "2"], [12, "4"]],"max_deployment_duration":'$MAX_DEPLOYMENT_DURATION'}'
 
     $NEUTRON_BINARY tx wasm instantiate $HYDRO_CODE_ID "$INIT_HYDRO" --admin $TX_SENDER_ADDRESS --label "'$HYDRO_SC_LABEL'" --from $TX_SENDER_WALLET $NEUTRON_TX_FLAGS --output json &> ./instantiate_hydro_res.json
     sleep 10


### PR DESCRIPTION
## Description

[DO NOT MERGE] Is due to the workflow trigger not being set properly in order to be able to test that the workflow actually works.

Added new `populate-staging-contracts` workflow that does the following:
- Gets triggered every day immediately after the new round starts (10:05 UTC)
- Enters liquidity deployment info for all proposals from the previous round
- Creates 3 proposals in new round, adds 2 tributes to first one, 1 tribute to second one, and no tributes to third one
- Locks some tokens (or refreshes the lock if there is some that is expired) and uses that lockup to vote for one proposal in both tranches (ATOM and USDC).

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] Targeted the correct branch
* [ ] Included the necessary unit tests
* [ ] Added/adjusted the necessary [interchain tests](./test/interchain/)
* [ ] Added a changelog entry in `.changelog`
* [ ] Compiled the contracts by using `make compile` and included content of the *artifacts* directory into the PR
* [ ] Regenerated front-end schema by using `make schema` and included generated files into the PR
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary
* [ ] Confirmed all CI checks have passed
