### PR TITLE
Inflow withdrawal workflow implementation

### DIFF
--- a/contracts/inflow/src/contract.rs
+++ b/contracts/inflow/src/contract.rs
@@ -1,12 +1,16 @@
-use std::env;
+use std::{
+    collections::{HashMap, HashSet},
+    env, vec,
+};
 
 use cosmos_sdk_proto::cosmos::bank::v1beta1::{DenomUnit, Metadata};
 use cosmwasm_std::{
     entry_point, from_json, to_json_binary, to_json_vec, Addr, AnyMsg, BankMsg, Binary, Coin,
-    CosmosMsg, Decimal, Deps, DepsMut, Env, MessageInfo, Order, Reply, Response, StdError,
-    StdResult, SubMsg, Uint128,
+    ConversionOverflowError, CosmosMsg, Decimal, Deps, DepsMut, Env, Int128, MessageInfo, Order,
+    Reply, Response, StdError, StdResult, Storage, SubMsg, Uint128,
 };
 use cw2::set_contract_version;
+use cw_storage_plus::Bound;
 use neutron_sdk::{
     bindings::{msg::NeutronMsg, query::NeutronQuery},
     proto_types::osmosis::tokenfactory::v1beta1::MsgSetDenomMetadata,
@@ -16,10 +20,18 @@ use neutron_sdk::{
 use prost::Message;
 
 use crate::{
-    error::ContractError,
+    error::{new_generic_error, ContractError},
     msg::{DenomMetadata, ExecuteMsg, InstantiateMsg, ReplyPayload},
-    query::{ConfigResponse, QueryMsg},
-    state::{load_config, Config, CONFIG, DEPLOYED_AMOUNT, VAULT_SHARES_DENOM, WHITELIST},
+    query::{
+        ConfigResponse, FundedWithdrawalRequestsResponse, QueryMsg, UserPayoutsHistoryResponse,
+        UserWithdrawalRequestsResponse, WithdrawalQueueInfoResponse,
+    },
+    state::{
+        get_next_payout_id, get_next_withdrawal_id, load_config, Config, PayoutEntry,
+        WithdrawalEntry, WithdrawalQueueInfo, CONFIG, DEPLOYED_AMOUNT, LAST_FUNDED_WITHDRAWAL_ID,
+        NEXT_PAYOUT_ID, NEXT_WITHDRAWAL_ID, PAYOUTS_HISTORY, USER_WITHDRAWAL_REQUESTS, WHITELIST,
+        WITHDRAWAL_QUEUE_INFO, WITHDRAWAL_REQUESTS,
+    },
 };
 
 /// Contract name that is used for migration.
@@ -42,10 +54,23 @@ pub fn instantiate(
         deps.storage,
         &Config {
             deposit_denom: msg.deposit_denom.clone(),
+            vault_shares_denom: String::new(),
+            max_withdrawals_per_user: msg.max_withdrawals_per_user,
         },
     )?;
 
     DEPLOYED_AMOUNT.save(deps.storage, &Uint128::zero(), env.block.height)?;
+    NEXT_WITHDRAWAL_ID.save(deps.storage, &0u64)?;
+    NEXT_PAYOUT_ID.save(deps.storage, &0u64)?;
+
+    WITHDRAWAL_QUEUE_INFO.save(
+        deps.storage,
+        &WithdrawalQueueInfo {
+            total_shares_burned: Uint128::zero(),
+            total_withdrawal_amount: Uint128::zero(),
+            non_funded_withdrawal_amount: Uint128::zero(),
+        },
+    )?;
 
     let whitelist_addresses = msg
         .whitelist
@@ -54,9 +79,9 @@ pub fn instantiate(
         .collect::<Vec<_>>();
 
     if whitelist_addresses.is_empty() {
-        return Err(ContractError::Std(StdError::generic_err(
+        return Err(new_generic_error(
             "at least one whitelist address must be provided",
-        )));
+        ));
     }
 
     for whitelist_address in &whitelist_addresses {
@@ -86,6 +111,10 @@ pub fn instantiate(
                 .map(|addr| addr.to_string())
                 .collect::<Vec<String>>()
                 .join(", "),
+        )
+        .add_attribute(
+            "max_withdrawals_per_user",
+            msg.max_withdrawals_per_user.to_string(),
         ))
 }
 
@@ -100,6 +129,16 @@ pub fn execute(
 
     match msg {
         ExecuteMsg::Deposit {} => deposit(deps, env, info, &config),
+        ExecuteMsg::Withraw {} => withdraw(deps, env, info, &config),
+        ExecuteMsg::CancelWithrawal { withdrawal_ids } => {
+            cancel_withdrawal(deps, info, &config, withdrawal_ids)
+        }
+        ExecuteMsg::FulfillPendingWithdrawals { limit } => {
+            fulfill_pending_withdrawals(deps, env, info, &config, limit)
+        }
+        ExecuteMsg::ClaimUnbondedWithdrawals { withdrawal_ids } => {
+            claim_unbonded_withdrawals(deps, env, info, &config, withdrawal_ids)
+        }
         ExecuteMsg::WithdrawForDeployment { amount } => {
             withdraw_for_deployment(deps, env, info, &config, amount)
         }
@@ -126,7 +165,7 @@ fn deposit(
         calculate_number_of_shares_to_mint(&deps.as_ref(), &env, config, deposit_amount)?;
 
     let mint_vault_shares_msg = NeutronMsg::submit_mint_tokens(
-        &VAULT_SHARES_DENOM.load(deps.storage)?,
+        &config.vault_shares_denom,
         vault_shares_to_mint,
         &info.sender,
     );
@@ -139,6 +178,443 @@ fn deposit(
         .add_attribute("vault_shares_minted", vault_shares_to_mint))
 }
 
+// User initiates withdrawal request by sending a certain number of vault shares tokens to the contract
+// in order to redeem them for the underlying deposit tokens. If the contract has enough balance
+// to cover the entire amount from existing withdrawal queue plus the new request, user will
+// receive deposit tokens immediately. Otherwise, the request will be added to the withdrawal queue.
+// In both cases, the vault shares tokens sent by the user will be burned immediately.
+fn withdraw(
+    deps: DepsMut<NeutronQuery>,
+    env: Env,
+    info: MessageInfo,
+    config: &Config,
+) -> Result<Response<NeutronMsg>, ContractError> {
+    let vault_shares_denom = config.vault_shares_denom.clone();
+    let vault_shares_sent = cw_utils::must_pay(&info, &vault_shares_denom)?;
+
+    // Calculate how many deposit tokens the sent vault shares are worth
+    let amount_to_withdraw =
+        query_shares_equivalent_value(&deps.as_ref(), &env, vault_shares_sent)?;
+
+    if amount_to_withdraw.is_zero() {
+        return Err(new_generic_error("cannot withdraw zero amount"));
+    }
+
+    // Get the current contract balance of the deposit token
+    let contract_balance = deps
+        .querier
+        .query_balance(
+            env.contract.address.to_string(),
+            config.deposit_denom.clone(),
+        )?
+        .amount;
+
+    // Get the total amount already requested for withdrawal
+    let withdrawal_queue_amount = WITHDRAWAL_QUEUE_INFO
+        .load(deps.storage)?
+        .total_withdrawal_amount;
+
+    let mut response = Response::new()
+        .add_attribute("action", "withdraw")
+        .add_attribute("sender", info.sender.clone())
+        .add_attribute("vault_shares_sent", vault_shares_sent);
+
+    // If the contract has enough balance to cover the entire withdrawal queue amount
+    // plus the new request, send the tokens to the user immediately.
+    if withdrawal_queue_amount.checked_add(amount_to_withdraw)? <= contract_balance {
+        response = response
+            .add_message(BankMsg::Send {
+                to_address: info.sender.to_string(),
+                amount: vec![Coin::new(amount_to_withdraw, config.deposit_denom.clone())],
+            })
+            .add_attribute("withdrawn_amount", amount_to_withdraw);
+
+        // Add entry to the payout history
+        add_payout_history_entry(
+            deps.storage,
+            &env,
+            &info.sender,
+            vault_shares_sent,
+            amount_to_withdraw,
+        )?;
+    } else {
+        let withdrawal_id = get_next_withdrawal_id(deps.storage)?;
+
+        let withdrawal_entry = WithdrawalEntry {
+            id: withdrawal_id,
+            initiated_at: env.block.time,
+            withdrawer: info.sender.clone(),
+            shares_burned: vault_shares_sent,
+            amount_to_receive: amount_to_withdraw,
+            is_funded: false,
+        };
+
+        // Add the new withdrawal entry to the queue
+        WITHDRAWAL_REQUESTS.save(deps.storage, withdrawal_id, &withdrawal_entry)?;
+
+        // Update the withdrawal queue info
+        update_withdrawal_queue_info(
+            deps.storage,
+            Some(Int128::try_from(vault_shares_sent)?),
+            Some(Int128::try_from(amount_to_withdraw)?),
+            Some(Int128::try_from(amount_to_withdraw)?),
+        )?;
+
+        // Add the new withdrawal id to the list of user's withdrawal requests
+        update_user_withdrawal_requests_info(
+            deps.storage,
+            info.sender.clone(),
+            config,
+            Some(vec![withdrawal_id]),
+            None,
+        )?;
+
+        response = response
+            .add_attribute("withdrawal_id", withdrawal_id.to_string())
+            .add_attribute("amount_to_withdraw", amount_to_withdraw);
+    }
+
+    // Burn the vault shares tokens sent by the user
+    let burn_shares_msg = NeutronMsg::submit_burn_tokens(&vault_shares_denom, vault_shares_sent);
+
+    Ok(response.add_message(burn_shares_msg))
+}
+
+// Users can cancel any of their pending withdrawal requests until the funds for those withdrawals
+// have been provided to the smart contract. Users will receive back the vault shares tokens they
+// had previously sent to the contract when creating the withdrawal requests that are now being canceled.
+fn cancel_withdrawal(
+    deps: DepsMut<NeutronQuery>,
+    info: MessageInfo,
+    config: &Config,
+    withdrawal_ids: Vec<u64>,
+) -> Result<Response<NeutronMsg>, ContractError> {
+    // Users can only cancel withdrawals for which the funds have not been provided yet.
+    let lowest_id_allowed_to_cancel = LAST_FUNDED_WITHDRAWAL_ID
+        .may_load(deps.storage)?
+        .map(|id| id + 1)
+        .unwrap_or_default();
+
+    let user_withdrawals: HashSet<u64> = USER_WITHDRAWAL_REQUESTS
+        .may_load(deps.storage, info.sender.clone())?
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+
+    let mut withdrawals_to_process: HashSet<u64> = HashSet::new();
+    let mut withdrawals_to_skip: HashSet<u64> = HashSet::new();
+
+    // Ensure that:
+    //   1. Sender is the owner of withdrawal requests
+    //   2. Withdrawal requests have not been funded yet
+    //   3. No duplicate withdrawal IDs are processed
+    for withdrawal_id in withdrawal_ids {
+        if !user_withdrawals.contains(&withdrawal_id) || withdrawal_id < lowest_id_allowed_to_cancel
+        {
+            withdrawals_to_skip.insert(withdrawal_id);
+        } else {
+            withdrawals_to_process.insert(withdrawal_id);
+        }
+    }
+
+    let response = Response::new()
+        .add_attribute("action", "cancel_withdrawal")
+        .add_attribute("sender", info.sender.clone())
+        .add_attribute(
+            "withdrawal_ids_processed",
+            get_slice_as_attribute(
+                withdrawals_to_process
+                    .iter()
+                    .collect::<Vec<&u64>>()
+                    .as_slice(),
+            ),
+        )
+        .add_attribute(
+            "withdrawal_ids_skipped",
+            get_slice_as_attribute(withdrawals_to_skip.iter().collect::<Vec<&u64>>().as_slice()),
+        );
+
+    if withdrawals_to_process.is_empty() {
+        return Ok(response);
+    }
+
+    let mut shares_burned = Uint128::zero();
+    let mut amount_to_withdraw = Uint128::zero();
+
+    for withdrawal_id in &withdrawals_to_process {
+        // USER_WITHDRAWAL_REQUESTS should always be in sync with WITHDRAWAL_REQUESTS.
+        // If the withdrawal entry is not found, the entire execute() action should fail.
+        let withdrawal_entry = WITHDRAWAL_REQUESTS.load(deps.storage, *withdrawal_id)?;
+
+        // Double check that the withdrawal belongs to the sender and has not been funded yet
+        if withdrawal_entry.withdrawer != info.sender || withdrawal_entry.is_funded {
+            return Err(new_generic_error(format!(
+                "withdrawal request {withdrawal_id} cannot be cancelled"
+            )));
+        }
+
+        shares_burned = shares_burned.checked_add(withdrawal_entry.shares_burned)?;
+        amount_to_withdraw = amount_to_withdraw.checked_add(withdrawal_entry.amount_to_receive)?;
+
+        // Remove the withdrawal entry from the queue
+        WITHDRAWAL_REQUESTS.remove(deps.storage, withdrawal_entry.id);
+    }
+
+    // Remove canceled withdrawal ids from the list of user's pending withdrawal requests
+    update_user_withdrawal_requests_info(
+        deps.storage,
+        info.sender.clone(),
+        config,
+        None,
+        Some(withdrawals_to_process.into_iter().collect()),
+    )?;
+
+    // Subtract the burned shares and canceled amounts from the withdrawal queue info
+    update_withdrawal_queue_info(
+        deps.storage,
+        Some(Int128::try_from(shares_burned)?.strict_neg()),
+        Some(Int128::try_from(amount_to_withdraw)?.strict_neg()),
+        Some(Int128::try_from(amount_to_withdraw)?.strict_neg()),
+    )?;
+
+    // Mint back the vault shares tokens that were burned when the withdrawal requests were created
+    let mint_vault_shares_msg =
+        NeutronMsg::submit_mint_tokens(&config.vault_shares_denom, shares_burned, &info.sender);
+
+    Ok(response
+        .add_message(mint_vault_shares_msg)
+        .add_attribute("canceled_withdrawal_amount", amount_to_withdraw)
+        .add_attribute("shares_minted_back", shares_burned))
+}
+
+// Permissionless action that iterates over the withdrawal requests queue and marks as funded all
+// those withdrawal requests that can be paid out with the funds held by the contract, but also
+// considering the funds already allocated for earlier requests that have not been paid out yet.
+fn fulfill_pending_withdrawals(
+    deps: DepsMut<NeutronQuery>,
+    env: Env,
+    info: MessageInfo,
+    config: &Config,
+    limit: u64,
+) -> Result<Response<NeutronMsg>, ContractError> {
+    // If this action is being executed for the first time, start from withdrawal ID 0.
+    // Otherwise, start from the last funded withdrawal ID increased by 1.
+    let start = LAST_FUNDED_WITHDRAWAL_ID
+        .may_load(deps.storage)?
+        .map(|id| id + 1)
+        .unwrap_or_default();
+
+    let withdrawals = WITHDRAWAL_REQUESTS
+        .range(
+            deps.storage,
+            Some(Bound::inclusive(start)),
+            None,
+            Order::Ascending,
+        )
+        .take(limit as usize)
+        .filter_map(|withdrawal| {
+            match withdrawal {
+                Ok((_, withdrawal)) => {
+                    // It should never happen that a withdrawal entry after the last funded ID
+                    // has already been provided with the funds, but we check that just in case.
+                    if withdrawal.is_funded {
+                        return None;
+                    }
+
+                    Some(withdrawal)
+                }
+                Err(_) => None,
+            }
+        })
+        .collect::<Vec<WithdrawalEntry>>();
+
+    let withdrawal_queue_info = WITHDRAWAL_QUEUE_INFO.load(deps.storage)?;
+
+    let mut available_balance = get_balance_available_for_pending_withdrawals(
+        &deps.as_ref(),
+        env.contract.address.as_ref(),
+        &config.deposit_denom,
+        &withdrawal_queue_info,
+    )?;
+
+    let response = Response::new()
+        .add_attribute("action", "fulfill_pending_withdrawals")
+        .add_attribute("sender", info.sender);
+
+    if available_balance.is_zero() {
+        return Ok(response
+            .add_attribute("funded_withdrawal_ids", "")
+            .add_attribute("total_amount_funded", Uint128::zero()));
+    }
+
+    let mut total_amount_funded = Uint128::zero();
+    let mut funded_withdrawal_ids = vec![];
+
+    for mut withdrawal in withdrawals {
+        if withdrawal.amount_to_receive > available_balance {
+            break;
+        }
+
+        withdrawal.is_funded = true;
+        total_amount_funded = total_amount_funded.checked_add(withdrawal.amount_to_receive)?;
+        funded_withdrawal_ids.push(withdrawal.id);
+        available_balance = available_balance.checked_sub(withdrawal.amount_to_receive)?;
+
+        WITHDRAWAL_REQUESTS.save(deps.storage, withdrawal.id, &withdrawal)?;
+    }
+
+    if !total_amount_funded.is_zero() {
+        // Update the withdrawal queue info by reducing the non-funded amount
+        update_withdrawal_queue_info(
+            deps.storage,
+            None,
+            None,
+            Some(Int128::try_from(total_amount_funded)?.strict_neg()),
+        )?;
+
+        // Update the last funded withdrawal ID
+        LAST_FUNDED_WITHDRAWAL_ID
+            .save(deps.storage, funded_withdrawal_ids.iter().max().unwrap())?;
+    }
+
+    Ok(response
+        .add_attribute(
+            "funded_withdrawal_ids",
+            get_slice_as_attribute(funded_withdrawal_ids.as_slice()),
+        )
+        .add_attribute("total_amount_funded", total_amount_funded))
+}
+
+// Permissionless action that iterates over the provided list of withdrawal IDs and executes the
+// actual payouts for those withdrawals that have already had the funds provided to the contract.
+// Withdrawal entries must first be marked as ready for payout, which is achieved by executing
+// the `fulfill_pending_withdrawals()` action.
+fn claim_unbonded_withdrawals(
+    deps: DepsMut<NeutronQuery>,
+    env: Env,
+    info: MessageInfo,
+    config: &Config,
+    withdrawal_ids: Vec<u64>,
+) -> Result<Response<NeutronMsg>, ContractError> {
+    let Some(last_funded_withdrawal_id) = LAST_FUNDED_WITHDRAWAL_ID.may_load(deps.storage)? else {
+        return Err(new_generic_error(
+            "no withdrawal requests have been funded yet",
+        ));
+    };
+
+    // Remove duplicates and filter out any withdrawal IDs that haven't been marked as funded yet
+    let withdrawal_ids = withdrawal_ids
+        .into_iter()
+        .filter(|withdrawal_id| withdrawal_id <= &last_funded_withdrawal_id)
+        .collect::<HashSet<u64>>();
+
+    let withdrawals = withdrawal_ids
+        .into_iter()
+        .filter_map(|withdrawal_id| {
+            match WITHDRAWAL_REQUESTS.may_load(deps.storage, withdrawal_id) {
+                Ok(withdrawal) => {
+                    let withdrawal = withdrawal?;
+
+                    // Double check that the withdrawal has been funded, just in case
+                    if !withdrawal.is_funded {
+                        return None;
+                    }
+
+                    Some(withdrawal)
+                }
+                Err(_) => None,
+            }
+        })
+        .collect::<Vec<WithdrawalEntry>>();
+
+    if withdrawals.is_empty() {
+        return Err(new_generic_error(
+            "must provide at least one valid withdrawal id",
+        ));
+    }
+
+    let mut total_shares_burned = Uint128::zero();
+    let mut total_amount_withdrawn = Uint128::zero();
+    let mut users_withdrawals: HashMap<Addr, Vec<WithdrawalEntry>> = HashMap::new();
+
+    for withdrawal in &withdrawals {
+        let user_withdrawals = users_withdrawals
+            .entry(withdrawal.withdrawer.clone())
+            .or_default();
+
+        user_withdrawals.push(withdrawal.clone());
+
+        total_amount_withdrawn =
+            total_amount_withdrawn.checked_add(withdrawal.amount_to_receive)?;
+
+        total_shares_burned = total_shares_burned.checked_add(withdrawal.shares_burned)?;
+
+        WITHDRAWAL_REQUESTS.remove(deps.storage, withdrawal.id);
+    }
+
+    let mut messages = vec![];
+
+    for user_withdrawals in &users_withdrawals {
+        let mut withdrawal_ids_to_remove = vec![];
+        let mut amount_to_withdraw = Uint128::zero();
+        let mut vault_shares_burned = Uint128::zero();
+
+        let recipient = user_withdrawals.0;
+        for withdrawal in user_withdrawals.1 {
+            withdrawal_ids_to_remove.push(withdrawal.id);
+            amount_to_withdraw = amount_to_withdraw.checked_add(withdrawal.amount_to_receive)?;
+            vault_shares_burned = vault_shares_burned.checked_add(withdrawal.shares_burned)?;
+        }
+
+        // Remove the processed withdrawal ids from the list of user's pending withdrawal requests
+        update_user_withdrawal_requests_info(
+            deps.storage,
+            recipient.clone(),
+            config,
+            None,
+            Some(withdrawal_ids_to_remove),
+        )?;
+
+        // Prepare bank message to send the tokens to the user
+        messages.push(CosmosMsg::Bank(BankMsg::Send {
+            to_address: recipient.to_string(),
+            amount: vec![Coin::new(amount_to_withdraw, config.deposit_denom.clone())],
+        }));
+
+        // Add entry to the payout history
+        add_payout_history_entry(
+            deps.storage,
+            &env,
+            recipient,
+            vault_shares_burned,
+            amount_to_withdraw,
+        )?;
+    }
+
+    update_withdrawal_queue_info(
+        deps.storage,
+        Some(Int128::try_from(total_shares_burned)?.strict_neg()),
+        Some(Int128::try_from(total_amount_withdrawn)?.strict_neg()),
+        None,
+    )?;
+
+    Ok(Response::new()
+        .add_messages(messages)
+        .add_attribute("action", "claim_unbonded_withdrawals")
+        .add_attribute("sender", info.sender)
+        .add_attribute(
+            "withdrawal_ids",
+            get_slice_as_attribute(
+                withdrawals
+                    .iter()
+                    .map(|w| w.id)
+                    .collect::<Vec<u64>>()
+                    .as_slice(),
+            ),
+        )
+        .add_attribute("total_amount_withdrawn", total_amount_withdrawn))
+}
+
 // Withdraws the specified amount for deployment.
 fn withdraw_for_deployment(
     deps: DepsMut<NeutronQuery>,
@@ -149,20 +625,26 @@ fn withdraw_for_deployment(
 ) -> Result<Response<NeutronMsg>, ContractError> {
     validate_address_is_whitelisted(&deps, info.sender.clone())?;
 
+    let available_for_deployment = query_available_for_deployment(&deps.as_ref(), &env)?;
+    if available_for_deployment.is_zero() {
+        return Err(new_generic_error("no funds are available for deployment"));
+    }
+
+    // If the requested amount exceeds the available amount, withdraw only what is available.
+    let amount_to_withdraw = available_for_deployment.min(amount);
+
     // We can update the deployed amount immediately, since we know it is now transferred to the multisig.
     DEPLOYED_AMOUNT.update(deps.storage, env.block.height, |current_value| {
         current_value
             .unwrap_or_default()
-            .checked_add(amount)
-            .map_err(|e| StdError::generic_err(format!("overflow error: {e}")))
+            .checked_add(amount_to_withdraw)
+            .map_err(|e| new_generic_error(format!("overflow error: {e}")))
     })?;
 
-    // There is no need to check if the smart contract balance has the required
-    // amount of tokens deposited, since the transaction will fail if it doesn't.
     let send_tokens_msg = BankMsg::Send {
         to_address: info.sender.to_string(),
         amount: vec![Coin {
-            amount,
+            amount: amount_to_withdraw,
             denom: config.deposit_denom.clone(),
         }],
     };
@@ -171,7 +653,8 @@ fn withdraw_for_deployment(
         .add_message(send_tokens_msg)
         .add_attribute("action", "withdraw_for_deployment")
         .add_attribute("sender", info.sender)
-        .add_attribute("amount", amount))
+        .add_attribute("amount_requested", amount)
+        .add_attribute("amount_withdrawn", amount_to_withdraw))
 }
 
 // Adds a new account address to the whitelist.
@@ -189,9 +672,9 @@ fn add_to_whitelist(
         .may_load(deps.storage, whitelist_address.clone())?
         .is_some()
     {
-        return Err(ContractError::Std(StdError::generic_err(format!(
+        return Err(new_generic_error(format!(
             "address {whitelist_address} is already in the whitelist"
-        ))));
+        )));
     }
 
     // Add address to whitelist
@@ -218,9 +701,9 @@ fn remove_from_whitelist(
         .may_load(deps.storage, whitelist_address.clone())?
         .is_none()
     {
-        return Err(ContractError::Std(StdError::generic_err(format!(
+        return Err(new_generic_error(format!(
             "address {whitelist_address} is not in the whitelist"
-        ))));
+        )));
     }
 
     // Remove address from the whitelist
@@ -231,9 +714,9 @@ fn remove_from_whitelist(
         .count()
         == 0
     {
-        return Err(ContractError::Std(StdError::generic_err(
+        return Err(new_generic_error(
             "cannot remove last outstanding whitelisted address",
-        )));
+        ));
     }
 
     Ok(Response::new()
@@ -270,12 +753,18 @@ pub fn calculate_number_of_shares_to_mint(
         .amount;
 
     let deployed_amount = DEPLOYED_AMOUNT.load(deps.storage)?;
+    let withdrawal_queue_amount = WITHDRAWAL_QUEUE_INFO
+        .load(deps.storage)?
+        .total_withdrawal_amount;
 
     // `deposit_amount` has already been added to the smart contract balance even before `execute()` is called,
     // so we need to subtract it here in order to accurately calculate number of vault shares to mint.
+    // We also need to add the amount already deployed and subtract the amount requested for withdrawal.
     let deposit_token_current_balance = contract_deposit_token_balance
         .checked_sub(deposit_amount)?
-        .checked_add(deployed_amount)?;
+        .checked_add(deployed_amount)?
+        .checked_sub(withdrawal_queue_amount)
+        .unwrap_or_default();
 
     let total_shares_issued = query_total_shares_issued(deps)?;
 
@@ -286,7 +775,7 @@ pub fn calculate_number_of_shares_to_mint(
 
     deposit_amount
         .checked_multiply_ratio(total_shares_issued, deposit_token_current_balance)
-        .map_err(|e| ContractError::Std(StdError::generic_err(format!("overflow error: {e}"))))
+        .map_err(|e| new_generic_error(format!("overflow error: {e}")))
 }
 
 fn submit_deployed_amount(
@@ -312,14 +801,39 @@ pub fn query(deps: Deps<NeutronQuery>, env: Env, msg: QueryMsg) -> StdResult<Bin
     match msg {
         QueryMsg::Config {} => to_json_binary(&query_config(&deps)?),
         QueryMsg::TotalSharesIssued {} => to_json_binary(&query_total_shares_issued(&deps)?),
-        QueryMsg::TotalPoolValue {} => to_json_binary(&query_total_pool_value(&deps, env)?),
+        QueryMsg::TotalPoolValue {} => to_json_binary(&query_total_pool_value(&deps, &env)?),
         QueryMsg::SharesEquivalentValue { shares } => {
-            to_json_binary(&query_shares_equivalent_value(&deps, env, shares)?)
+            to_json_binary(&query_shares_equivalent_value(&deps, &env, shares)?)
         }
         QueryMsg::UserSharesEquivalentValue { address } => {
-            to_json_binary(&query_user_shares_equivalent_value(&deps, env, address)?)
+            to_json_binary(&query_user_shares_equivalent_value(&deps, &env, address)?)
         }
         QueryMsg::DeployedAmount {} => to_json_binary(&query_deployed_amount(&deps)?),
+        QueryMsg::AvailableForDeployment {} => {
+            to_json_binary(&query_available_for_deployment(&deps, &env)?)
+        }
+        QueryMsg::WithdrawalQueueInfo {} => to_json_binary(&query_withdrawal_queue_info(&deps)?),
+        QueryMsg::AmountToFundPendingWithdrawals {} => {
+            to_json_binary(&query_amount_to_fund_pending_withdrawals(&deps, &env)?)
+        }
+        QueryMsg::FundedWithdrawalRequests { limit } => {
+            to_json_binary(&query_funded_withdrawal_requests(&deps, limit)?)
+        }
+        QueryMsg::UserWithdrawalRequests {
+            address,
+            start_from,
+            limit,
+        } => to_json_binary(&query_user_withdrawal_requests(
+            &deps, address, start_from, limit,
+        )?),
+        QueryMsg::UserPayoutsHistory {
+            address,
+            start_from,
+            limit,
+            order,
+        } => to_json_binary(&query_user_payouts_history(
+            &deps, address, start_from, limit, order,
+        )?),
     }
 }
 
@@ -332,35 +846,42 @@ fn query_config(deps: &Deps<NeutronQuery>) -> StdResult<ConfigResponse> {
 fn query_total_shares_issued(deps: &Deps<NeutronQuery>) -> StdResult<Uint128> {
     Ok(deps
         .querier
-        .query_supply(VAULT_SHARES_DENOM.load(deps.storage)?)?
+        .query_supply(load_config(deps.storage)?.vault_shares_denom)?
         .amount)
 }
 
-fn query_total_pool_value(deps: &Deps<NeutronQuery>, env: Env) -> StdResult<Uint128> {
+fn query_total_pool_value(deps: &Deps<NeutronQuery>, env: &Env) -> StdResult<Uint128> {
     let config = load_config(deps.storage)?;
     let denom = config.deposit_denom;
 
     // Get the current balance of this contract in the deposit denom
     let balance: Coin = deps
         .querier
-        .query_balance(env.contract.address, denom.clone())?;
+        .query_balance(env.contract.address.clone(), denom.clone())?;
 
     // Get the total deployed amount (from snapshot storage)
     let deployed_amount = DEPLOYED_AMOUNT.may_load(deps.storage)?;
 
+    // Get the total amount already requested for withdrawal. This amount should be
+    // subtracted from the total pool value, since we cannot count on it anymore.
+    let withdrawal_queue_amount = WITHDRAWAL_QUEUE_INFO
+        .load(deps.storage)?
+        .total_withdrawal_amount;
+
     Ok(balance
         .amount
-        .checked_add(deployed_amount.unwrap_or_default())?)
+        .checked_add(deployed_amount.unwrap_or_default())?
+        .checked_sub(withdrawal_queue_amount)
+        .unwrap_or_default())
 }
 
 /// Returns the value equivalent of a given amount of shares based on the current total shares and pool value.
 fn query_shares_equivalent_value(
     deps: &Deps<NeutronQuery>,
-    env: Env,
+    env: &Env,
     shares: Uint128,
 ) -> StdResult<Uint128> {
     let total_shares_supply = query_total_shares_issued(deps)?;
-
     let total_pool_value = query_total_pool_value(deps, env)?;
 
     calculate_shares_value(shares, total_shares_supply, total_pool_value)
@@ -369,28 +890,156 @@ fn query_shares_equivalent_value(
 /// Returns the value equivalent of a user's shares by querying their balance and calculating its worth based on total shares and pool value.
 fn query_user_shares_equivalent_value(
     deps: &Deps<NeutronQuery>,
-    env: Env,
+    env: &Env,
     address: String,
 ) -> StdResult<Uint128> {
-    let shares_denom = VAULT_SHARES_DENOM.load(deps.storage)?;
+    let shares_denom = load_config(deps.storage)?.vault_shares_denom.clone();
 
     // Get the current balance of this address in the shares denom
-    let shares_balance: Uint128 = deps
-        .querier
-        .query_balance(address, shares_denom.clone())?
-        .amount;
+    let shares_balance: Uint128 = deps.querier.query_balance(address, shares_denom)?.amount;
 
-    let total_shares_supply = query_total_shares_issued(deps)?;
-
-    let total_pool_value = query_total_pool_value(deps, env)?;
-
-    calculate_shares_value(shares_balance, total_shares_supply, total_pool_value)
+    query_shares_equivalent_value(deps, env, shares_balance)
 }
 
 fn query_deployed_amount(deps: &Deps<NeutronQuery>) -> StdResult<Uint128> {
     Ok(DEPLOYED_AMOUNT
         .may_load(deps.storage)?
         .unwrap_or_else(Uint128::zero))
+}
+
+pub fn query_available_for_deployment(deps: &Deps<NeutronQuery>, env: &Env) -> StdResult<Uint128> {
+    let config = load_config(deps.storage)?;
+    let withdrawal_queue_info = WITHDRAWAL_QUEUE_INFO.load(deps.storage)?;
+
+    let contract_balance = deps
+        .querier
+        .query_balance(env.contract.address.as_str(), config.deposit_denom)?
+        .amount;
+
+    Ok(
+        if contract_balance <= withdrawal_queue_info.total_withdrawal_amount {
+            Uint128::zero()
+        } else {
+            contract_balance.checked_sub(withdrawal_queue_info.total_withdrawal_amount)?
+        },
+    )
+}
+
+pub fn query_withdrawal_queue_info(
+    deps: &Deps<NeutronQuery>,
+) -> StdResult<WithdrawalQueueInfoResponse> {
+    Ok(WithdrawalQueueInfoResponse {
+        info: WITHDRAWAL_QUEUE_INFO.load(deps.storage)?,
+    })
+}
+
+pub fn query_amount_to_fund_pending_withdrawals(
+    deps: &Deps<NeutronQuery>,
+    env: &Env,
+) -> StdResult<Uint128> {
+    let config = load_config(deps.storage)?;
+    let withdrawal_queue_info = WITHDRAWAL_QUEUE_INFO.load(deps.storage)?;
+
+    // Determine how much is already available to fund pending withdrawals
+    let available_balance = get_balance_available_for_pending_withdrawals(
+        deps,
+        env.contract.address.as_ref(),
+        &config.deposit_denom,
+        &withdrawal_queue_info,
+    )?;
+
+    Ok(
+        if available_balance >= withdrawal_queue_info.non_funded_withdrawal_amount {
+            Uint128::zero()
+        } else {
+            withdrawal_queue_info
+                .non_funded_withdrawal_amount
+                .checked_sub(available_balance)?
+        },
+    )
+}
+
+fn query_funded_withdrawal_requests(
+    deps: &Deps<NeutronQuery>,
+    limit: u64,
+) -> StdResult<FundedWithdrawalRequestsResponse> {
+    // If no withdrawals have been funded yet, return an empty list. Otherwise, use last_funded_withdrawal_id
+    // to restrict the query range in order to make it more gas efficient.
+    let Some(last_funded_withdrawal_id) = LAST_FUNDED_WITHDRAWAL_ID.may_load(deps.storage)? else {
+        return Ok(FundedWithdrawalRequestsResponse {
+            withdrawal_ids: vec![],
+        });
+    };
+
+    let withdrawal_ids = WITHDRAWAL_REQUESTS
+        .range(
+            deps.storage,
+            None,
+            Some(Bound::inclusive(last_funded_withdrawal_id)),
+            Order::Ascending,
+        )
+        .take(limit as usize)
+        .filter_map(|entry| match entry {
+            Ok((_, withdrawal)) => {
+                if withdrawal.is_funded {
+                    Some(withdrawal.id)
+                } else {
+                    None
+                }
+            }
+            Err(_) => None,
+        })
+        .collect::<Vec<u64>>();
+
+    Ok(FundedWithdrawalRequestsResponse { withdrawal_ids })
+}
+
+pub fn query_user_withdrawal_requests(
+    deps: &Deps<NeutronQuery>,
+    address: String,
+    start_from: u32,
+    limit: u32,
+) -> StdResult<UserWithdrawalRequestsResponse> {
+    let user_address = deps.api.addr_validate(&address)?;
+
+    let mut withdrawal_ids = USER_WITHDRAWAL_REQUESTS
+        .may_load(deps.storage, user_address.clone())?
+        .unwrap_or_default();
+
+    // Make sure that the withdrawl request IDs are always returned in the same order
+    withdrawal_ids.sort();
+
+    let withdrawals = withdrawal_ids
+        .into_iter()
+        .skip(start_from as usize)
+        .take(limit as usize)
+        .filter_map(|withdrawal_id| WITHDRAWAL_REQUESTS.load(deps.storage, withdrawal_id).ok())
+        .collect::<Vec<WithdrawalEntry>>();
+
+    Ok(UserWithdrawalRequestsResponse { withdrawals })
+}
+
+pub fn query_user_payouts_history(
+    deps: &Deps<NeutronQuery>,
+    address: String,
+    start_from: u32,
+    limit: u32,
+    order: Order,
+) -> StdResult<UserPayoutsHistoryResponse> {
+    let user_address = deps.api.addr_validate(&address)?;
+
+    let payouts = PAYOUTS_HISTORY
+        .prefix(user_address)
+        .range(deps.storage, None, None, order)
+        .skip(start_from as usize)
+        .take(limit as usize)
+        .filter_map(|entry| match entry {
+            Ok((_, payout)) => Some(payout),
+            Err(_) => None,
+        })
+        .collect::<Vec<PayoutEntry>>();
+
+    Ok(UserPayoutsHistoryResponse { payouts })
 }
 
 /// Calculates the value of `shares` relative to the `total_pool_value` based on `total_shares_supply`.
@@ -433,7 +1082,11 @@ pub fn reply(
             // Full denom name, e.g. "factory/{inflow_contract_address}/hydro_inflow_atom"
             let full_denom = query_full_denom(deps.as_ref(), &env.contract.address, subdenom)?;
 
-            VAULT_SHARES_DENOM.save(deps.storage, &full_denom.denom)?;
+            CONFIG.update(deps.storage, |mut config| -> Result<_, ContractError> {
+                config.vault_shares_denom = full_denom.denom.clone();
+
+                Ok(config)
+            })?;
 
             let msg = create_set_denom_metadata_msg(
                 env.contract.address.into_string(),
@@ -485,4 +1138,149 @@ fn create_set_denom_metadata_msg(
             .encode_to_vec(),
         ),
     })
+}
+
+/// Updates the list of user's pending withdrawal requestss by adding and/or removing specified withdrawal IDs.
+fn update_user_withdrawal_requests_info(
+    storage: &mut dyn Storage,
+    user: Addr,
+    config: &Config,
+    withdrawals_to_add: Option<Vec<u64>>,
+    withdrawals_to_remove: Option<Vec<u64>>,
+) -> Result<(), ContractError> {
+    USER_WITHDRAWAL_REQUESTS.update(
+        storage,
+        user.clone(),
+        |current_withdrawals| -> Result<_, ContractError> {
+            let mut current_withdrawals = current_withdrawals.unwrap_or_default();
+
+            if let Some(withdrawals_to_add) = withdrawals_to_add {
+                current_withdrawals.extend(withdrawals_to_add);
+            }
+
+            if let Some(withdrawals_to_remove) = withdrawals_to_remove {
+                let withdrawals_to_remove: HashSet<u64> = HashSet::from_iter(withdrawals_to_remove);
+
+                current_withdrawals.retain(|id| !withdrawals_to_remove.contains(id));
+            }
+
+            if (current_withdrawals.len() as u64) > config.max_withdrawals_per_user {
+                return Err(new_generic_error(format!(
+                    "user {} has reached the maximum number of pending withdrawals: {}",
+                    user, config.max_withdrawals_per_user
+                )));
+            }
+
+            Ok(current_withdrawals)
+        },
+    )?;
+    Ok(())
+}
+
+/// Updates the withdrawal queue info by applying the provided updates to its fields.
+fn update_withdrawal_queue_info(
+    storage: &mut dyn Storage,
+    shares_burned_update: Option<Int128>,
+    total_withdrawal_amount_update: Option<Int128>,
+    non_funded_withdrawal_amount_update: Option<Int128>,
+) -> Result<(), ContractError> {
+    fn get_resulting_value(
+        initial_value: Uint128,
+        update: Int128,
+    ) -> Result<Uint128, ContractError> {
+        let current_value: Int128 = initial_value.try_into()?;
+
+        current_value
+            .checked_add(update)
+            .map_err(|e| new_generic_error(format!("overflow error: {}", e)))?
+            .try_into()
+            .map_err(|e: ConversionOverflowError| {
+                new_generic_error(format!("conversion into Uint128 type failed; error: {}", e))
+            })
+    }
+
+    let mut withdrawal_queue_info = WITHDRAWAL_QUEUE_INFO.load(storage)?;
+
+    if let Some(shares_burned_update) = shares_burned_update {
+        withdrawal_queue_info.total_shares_burned = get_resulting_value(
+            withdrawal_queue_info.total_shares_burned,
+            shares_burned_update,
+        )?;
+    }
+
+    if let Some(total_withdrawal_amount_update) = total_withdrawal_amount_update {
+        withdrawal_queue_info.total_withdrawal_amount = get_resulting_value(
+            withdrawal_queue_info.total_withdrawal_amount,
+            total_withdrawal_amount_update,
+        )?
+    }
+
+    if let Some(non_funded_withdrawal_amount_update) = non_funded_withdrawal_amount_update {
+        withdrawal_queue_info.non_funded_withdrawal_amount = get_resulting_value(
+            withdrawal_queue_info.non_funded_withdrawal_amount,
+            non_funded_withdrawal_amount_update,
+        )?
+    }
+
+    WITHDRAWAL_QUEUE_INFO.save(storage, &withdrawal_queue_info)?;
+
+    Ok(())
+}
+
+/// Adds a new entry to the payout history for a user.
+fn add_payout_history_entry(
+    storage: &mut dyn Storage,
+    env: &Env,
+    recipient: &Addr,
+    vault_shares_burned: Uint128,
+    amount_received: Uint128,
+) -> Result<(), ContractError> {
+    let payout_id = get_next_payout_id(storage)?;
+
+    let payout_entry = PayoutEntry {
+        id: payout_id,
+        executed_at: env.block.time,
+        recipient: recipient.clone(),
+        vault_shares_burned,
+        amount_received,
+    };
+
+    PAYOUTS_HISTORY.save(storage, (recipient.clone(), payout_id), &payout_entry)?;
+
+    Ok(())
+}
+
+/// Calculates the balance available for funding pending withdrawals by subtracting the amount
+/// already allocated for earlier funded withdrawal requests from the current contract balance.
+fn get_balance_available_for_pending_withdrawals(
+    deps: &Deps<NeutronQuery>,
+    contract_address: &str,
+    deposit_denom: &str,
+    withdrawal_queue_info: &WithdrawalQueueInfo,
+) -> StdResult<Uint128> {
+    let contract_balance = deps
+        .querier
+        .query_balance(contract_address, deposit_denom)?
+        .amount;
+
+    // We cannot count on the tokens that were provided earlier for withdrawals but haven't been paid out
+    // to the users yet, so we only consider the portion of the contract balance that exceeds this amount.
+    let earlier_funded_withdrawal_amount = withdrawal_queue_info
+        .total_withdrawal_amount
+        .checked_sub(withdrawal_queue_info.non_funded_withdrawal_amount)?;
+
+    if contract_balance <= earlier_funded_withdrawal_amount {
+        return Ok(Uint128::zero());
+    }
+
+    Ok(contract_balance.checked_sub(earlier_funded_withdrawal_amount)?)
+}
+
+/// Converts a slice of items into a comma-separated string of their string representations.
+pub fn get_slice_as_attribute<T: ToString>(input: &[T]) -> String {
+    input
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<String>>()
+        .join(",")
 }

--- a/contracts/inflow/src/error.rs
+++ b/contracts/inflow/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{CheckedFromRatioError, OverflowError, StdError};
+use cosmwasm_std::{CheckedFromRatioError, ConversionOverflowError, OverflowError, StdError};
 use cw_utils::PaymentError;
 use neutron_sdk::NeutronError;
 use thiserror::Error;
@@ -17,9 +17,16 @@ pub enum ContractError {
     #[error("{0}")]
     CheckedFromRatioError(#[from] CheckedFromRatioError),
 
+    #[error("{0}")]
+    ConversionOverflowError(#[from] ConversionOverflowError),
+
     #[error(transparent)]
     NeutronError(#[from] NeutronError),
 
     #[error("Unauthorized")]
     Unauthorized,
+}
+
+pub fn new_generic_error(msg: impl Into<String>) -> ContractError {
+    ContractError::Std(StdError::generic_err(msg))
 }

--- a/contracts/inflow/src/msg.rs
+++ b/contracts/inflow/src/msg.rs
@@ -14,6 +14,8 @@ pub struct InstantiateMsg {
     pub token_metadata: DenomMetadata,
     /// List of addresses allowed to execute permissioned actions.
     pub whitelist: Vec<String>,
+    /// Maximum number of pending withdrawals per single user.
+    pub max_withdrawals_per_user: u64,
 }
 
 #[cw_serde]
@@ -39,6 +41,10 @@ pub struct DenomMetadata {
 #[cw_serde]
 pub enum ExecuteMsg {
     Deposit {},
+    Withraw {},
+    CancelWithrawal { withdrawal_ids: Vec<u64> },
+    FulfillPendingWithdrawals { limit: u64 },
+    ClaimUnbondedWithdrawals { withdrawal_ids: Vec<u64> },
     SubmitDeployedAmount { amount: Uint128 },
     WithdrawForDeployment { amount: Uint128 },
     AddToWhitelist { address: String },

--- a/contracts/inflow/src/query.rs
+++ b/contracts/inflow/src/query.rs
@@ -1,9 +1,10 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Order;
 // When compiling for wasm32 platform, compiler doesn't recognize that this type is used in one of the queries.
 #[allow(unused_imports)]
 use cosmwasm_std::Uint128;
 
-use crate::state::Config;
+use crate::state::{Config, PayoutEntry, WithdrawalEntry, WithdrawalQueueInfo};
 
 #[cw_serde]
 #[derive(QueryResponses)]
@@ -25,9 +26,64 @@ pub enum QueryMsg {
 
     #[returns(Uint128)]
     DeployedAmount {},
+
+    /// Returns the number of tokens that are available for deployment,
+    /// considering the amount required for any pending withdrawals.
+    #[returns(Uint128)]
+    AvailableForDeployment {},
+
+    #[returns(WithdrawalQueueInfoResponse)]
+    WithdrawalQueueInfo {},
+
+    /// Number of tokens that needs to be provided to the contract in order
+    /// to fund all pending withdrawal requests that have not been funded yet.
+    #[returns(Uint128)]
+    AmountToFundPendingWithdrawals {},
+
+    /// Returns a list of withdrawal request IDs that have been marked as funded
+    /// and are ready to be paid out to users, but have not been paid out yet.
+    #[returns(FundedWithdrawalRequestsResponse)]
+    FundedWithdrawalRequests { limit: u64 },
+
+    /// Returns a list of withdrawal requests made by the given user.
+    #[returns(UserWithdrawalRequestsResponse)]
+    UserWithdrawalRequests {
+        address: String,
+        start_from: u32,
+        limit: u32,
+    },
+
+    /// Returns a list of executed payouts for the given user.
+    #[returns(UserPayoutsHistoryResponse)]
+    UserPayoutsHistory {
+        address: String,
+        start_from: u32,
+        limit: u32,
+        order: Order,
+    },
 }
 
 #[cw_serde]
 pub struct ConfigResponse {
     pub config: Config,
+}
+
+#[cw_serde]
+pub struct FundedWithdrawalRequestsResponse {
+    pub withdrawal_ids: Vec<u64>,
+}
+
+#[cw_serde]
+pub struct WithdrawalQueueInfoResponse {
+    pub info: WithdrawalQueueInfo,
+}
+
+#[cw_serde]
+pub struct UserWithdrawalRequestsResponse {
+    pub withdrawals: Vec<WithdrawalEntry>,
+}
+
+#[cw_serde]
+pub struct UserPayoutsHistoryResponse {
+    pub payouts: Vec<PayoutEntry>,
 }

--- a/contracts/inflow/src/state.rs
+++ b/contracts/inflow/src/state.rs
@@ -1,5 +1,5 @@
 use cosmwasm_schema::cw_serde;
-use cosmwasm_std::{Addr, StdResult, Storage, Uint128};
+use cosmwasm_std::{Addr, StdResult, Storage, Timestamp, Uint128};
 use cw_storage_plus::{Item, Map, SnapshotItem, Strategy};
 
 /// Configuration of the Inflow smart contract
@@ -7,9 +7,6 @@ pub const CONFIG: Item<Config> = Item::new("config");
 
 /// Addresses that are allowed to execute permissioned actions on the smart contract.
 pub const WHITELIST: Map<Addr, ()> = Map::new("whitelist");
-
-/// Denom of the vault shares token that is issued to users when they deposit tokens into the vault.
-pub const VAULT_SHARES_DENOM: Item<String> = Item::new("vault_shares_denom");
 
 /// Number of tokens (in terms of the deposit asset) currently deployed by the whitelisted addresses.
 /// The value corresponds to the sum of principal user deposits and any yield earned through ongoing deployments.
@@ -21,11 +18,89 @@ pub const DEPLOYED_AMOUNT: SnapshotItem<Uint128> = SnapshotItem::new(
     Strategy::EveryBlock,
 );
 
+/// Next withdrawal ID to be used when a user makes a withdrawal request that ends up in the queue.
+pub const NEXT_WITHDRAWAL_ID: Item<u64> = Item::new("next_withdrawal_id");
+
+/// Keeps track of the last withdrawal ID that has been funded and marked as ready to be paid out to a user.
+pub const LAST_FUNDED_WITHDRAWAL_ID: Item<u64> = Item::new("last_funded_withdrawal_id");
+
+/// Next payout ID to be used to record history when a user actually gets the tokens paid out.
+pub const NEXT_PAYOUT_ID: Item<u64> = Item::new("next_payout_id");
+
+/// Pending withdrawal requests queue. The key is the withdrawal ID, and the value is a WithdrawalEntry.
+/// We use auto-incrementing withdrawal IDs to be able to fulfill withdrawal requests in a "first comes-
+/// first served" manner.
+/// WITHDRAWAL_REQUESTS: key(withdrawal_id) -> WithdrawalEntry
+pub const WITHDRAWAL_REQUESTS: Map<u64, WithdrawalEntry> = Map::new("withdrawal_requests");
+
+/// Information about the current state of withdrawal queue, including total shares burned,
+/// total withdrawal amount and withdrawal amount requested that hasn't been provided yet.
+pub const WITHDRAWAL_QUEUE_INFO: Item<WithdrawalQueueInfo> = Item::new("withdrawal_queue_info");
+
+/// Mapping from user address to a list of their current withdrawal request IDs.
+/// USER_WITHDRAWAL_REQUESTS: key(user_address) -> withdrawal_request_ids
+pub const USER_WITHDRAWAL_REQUESTS: Map<Addr, Vec<u64>> = Map::new("user_withdrawal_requests");
+
+/// History of all payouts made to users.
+/// PAYOUTS_HISTORY: key(user_address, payout_id) -> PayoutEntry
+pub const PAYOUTS_HISTORY: Map<(Addr, u64), PayoutEntry> = Map::new("payouts_history");
+
 #[cw_serde]
 pub struct Config {
+    /// Token denom that users can deposit into the vault.
     pub deposit_denom: String,
+    /// Denom of the vault shares token that is issued to users when they deposit tokens into the vault.
+    pub vault_shares_denom: String,
+    /// Maximum number of pending withdrawal requests allowed per user.
+    pub max_withdrawals_per_user: u64,
+}
+#[cw_serde]
+pub struct WithdrawalQueueInfo {
+    // Total shares burned for all withdrawals currently in the withdrawal queue.
+    pub total_shares_burned: Uint128,
+    // Total amount to be withdrawn for all withdrawal entries currently in the withdrawal queue.
+    // Sum of all `amount_to_receive` fields in all withdrawal entries, regardless of whether the
+    // funds for payouts have been provided to the smart contract or not.
+    pub total_withdrawal_amount: Uint128,
+    // Sum of `amount_to_receive` fields of all withdrawal entries from the withdrawal queue
+    // for which the funds have not been provided yet.
+    pub non_funded_withdrawal_amount: Uint128,
+}
+
+#[cw_serde]
+pub struct WithdrawalEntry {
+    pub id: u64,
+    pub initiated_at: Timestamp,
+    pub withdrawer: Addr,
+    pub shares_burned: Uint128,
+    pub amount_to_receive: Uint128,
+    pub is_funded: bool,
+}
+#[cw_serde]
+pub struct PayoutEntry {
+    pub id: u64,
+    pub executed_at: Timestamp,
+    pub recipient: Addr,
+    pub vault_shares_burned: Uint128,
+    pub amount_received: Uint128,
 }
 
 pub fn load_config(storage: &dyn Storage) -> StdResult<Config> {
     CONFIG.load(storage)
+}
+
+/// Retrieves the withdrawal ID to be used and increments the stored value for the next withdrawal ID.
+pub fn get_next_withdrawal_id(storage: &mut dyn Storage) -> StdResult<u64> {
+    let withdrawal_id = NEXT_WITHDRAWAL_ID.load(storage)?;
+    NEXT_WITHDRAWAL_ID.save(storage, &(withdrawal_id + 1))?;
+
+    Ok(withdrawal_id)
+}
+
+/// Retrieves the payout ID to be used and increments the stored value for the next payout ID.
+pub fn get_next_payout_id(storage: &mut dyn Storage) -> StdResult<u64> {
+    let payout_id = NEXT_PAYOUT_ID.load(storage)?;
+    NEXT_PAYOUT_ID.save(storage, &(payout_id + 1))?;
+
+    Ok(payout_id)
 }

--- a/contracts/inflow/src/testing.rs
+++ b/contracts/inflow/src/testing.rs
@@ -1,15 +1,21 @@
-use std::marker::PhantomData;
+use std::{collections::HashMap, marker::PhantomData};
 
 use crate::{
-    contract::{execute, instantiate, query},
+    contract::{
+        execute, instantiate, query, query_amount_to_fund_pending_withdrawals,
+        query_available_for_deployment, query_user_payouts_history, query_user_withdrawal_requests,
+        query_withdrawal_queue_info,
+    },
+    error::ContractError,
     msg::{DenomMetadata, ExecuteMsg, InstantiateMsg},
     query::QueryMsg,
-    state::{DEPLOYED_AMOUNT, VAULT_SHARES_DENOM},
+    state::{CONFIG, DEPLOYED_AMOUNT, LAST_FUNDED_WITHDRAWAL_ID},
 };
 use cosmwasm_std::{
     from_json,
     testing::{mock_env, MockApi, MockQuerier, MockStorage},
-    Addr, BankMsg, Coin, CosmosMsg, Env, MemoryStorage, MessageInfo, OwnedDeps, Uint128,
+    Addr, BalanceResponse, BankMsg, BankQuery, Coin, CosmosMsg, Env, MemoryStorage, MessageInfo,
+    Order, OwnedDeps, Uint128,
 };
 use neutron_sdk::bindings::{msg::NeutronMsg, query::NeutronQuery};
 
@@ -52,20 +58,9 @@ fn mock_address_balance(
     );
 }
 
-#[test]
-fn deposit_withdrawal_test() {
-    let (mut deps, mut env) = (mock_dependencies(), mock_env());
-
-    let inflow_contract_addr = deps.api.addr_make(INFLOW);
-    let whitelist_addr = deps.api.addr_make(WHITELIST_ADDR);
-    let user1_address = deps.api.addr_make(USER1);
-    let user2_address = deps.api.addr_make(USER2);
-    let user3_address = deps.api.addr_make(USER3);
-
-    env.contract.address = inflow_contract_addr.clone();
-
-    let instantiate_msg = InstantiateMsg {
-        deposit_denom: DEPOSIT_DENOM.to_string(),
+fn get_default_instantiate_msg(deposit_denom: &str, whitelist_addr: Addr) -> InstantiateMsg {
+    InstantiateMsg {
+        deposit_denom: deposit_denom.to_string(),
         whitelist: vec![whitelist_addr.to_string()],
         subdenom: "hydro_inflow_uatom".to_string(),
         token_metadata: DenomMetadata {
@@ -77,7 +72,36 @@ fn deposit_withdrawal_test() {
             uri: None,
             uri_hash: None,
         },
-    };
+        max_withdrawals_per_user: 10,
+    }
+}
+
+fn set_vault_shares_denom(
+    deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    vault_shares_denom_str: String,
+) {
+    CONFIG
+        .update(
+            &mut deps.storage,
+            |mut config| -> Result<_, ContractError> {
+                config.vault_shares_denom = vault_shares_denom_str;
+
+                Ok(config)
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn deposit_withdrawal_for_deployment_test() {
+    let (mut deps, mut env) = (mock_dependencies(), mock_env());
+
+    let inflow_contract_addr = deps.api.addr_make(INFLOW);
+    let whitelist_addr = deps.api.addr_make(WHITELIST_ADDR);
+
+    env.contract.address = inflow_contract_addr.clone();
+
+    let instantiate_msg = get_default_instantiate_msg(DEPOSIT_DENOM, whitelist_addr.clone());
 
     let info = get_message_info(&deps.api, "creator", &[]);
     instantiate(deps.as_mut(), env.clone(), info, instantiate_msg).unwrap();
@@ -85,52 +109,38 @@ fn deposit_withdrawal_test() {
     let vault_shares_denom_str: String =
         format!("factory/{inflow_contract_addr}/hydro_inflow_uatom");
 
-    VAULT_SHARES_DENOM
-        .save(deps.as_mut().storage, &vault_shares_denom_str.clone())
-        .unwrap();
+    set_vault_shares_denom(&mut deps, vault_shares_denom_str.clone());
 
     let user1_deposit1 = Uint128::new(1000);
     let user1_expected_shares1 = Uint128::new(1000);
 
-    // User1 deposits 1000 tokens -> mock this increase in the contract bank balance
-    mock_address_balance(
-        &mut deps,
-        inflow_contract_addr.as_ref(),
-        DEPOSIT_DENOM,
-        user1_deposit1,
-    );
-
+    // User1 deposits 1000 tokens
     execute_deposit(
         &mut deps,
         &env,
+        &inflow_contract_addr,
         USER1,
-        &user1_address,
         &vault_shares_denom_str,
         user1_deposit1,
         user1_expected_shares1,
         user1_expected_shares1,
+        user1_deposit1,
     );
 
     let user2_deposit1 = Uint128::new(3000);
     let user2_expected_shares1 = Uint128::new(3000);
 
-    // User2 deposits 3000 tokens -> mock this increase in the contract bank balance
-    mock_address_balance(
-        &mut deps,
-        inflow_contract_addr.as_ref(),
-        DEPOSIT_DENOM,
-        user1_deposit1 + user2_deposit1,
-    );
-
+    // User2 deposits 3000 tokens
     execute_deposit(
         &mut deps,
         &env,
+        &inflow_contract_addr,
         USER2,
-        &user2_address,
         &vault_shares_denom_str,
         user2_deposit1,
         user2_expected_shares1,
         user2_expected_shares1,
+        user1_deposit1 + user2_deposit1,
     );
 
     // Whitelisted address withdraws 4000 tokens for deployment
@@ -172,23 +182,17 @@ fn deposit_withdrawal_test() {
     let user1_deposit2 = Uint128::new(2000);
     let user1_expected_shares2 = Uint128::new(2000);
 
-    // User1 deposits 2000 tokens -> mock this increase in the contract bank balance
-    mock_address_balance(
-        &mut deps,
-        inflow_contract_addr.as_ref(),
-        DEPOSIT_DENOM,
-        user1_deposit2,
-    );
-
+    // User1 deposits 2000 tokens
     execute_deposit(
         &mut deps,
         &env,
+        &inflow_contract_addr,
         USER1,
-        &user1_address,
         &vault_shares_denom_str,
         user1_deposit2,
         user1_expected_shares2,
         user1_expected_shares1 + user1_expected_shares2,
+        user1_deposit2,
     );
 
     // Set DEPLOYED_AMOUNT to 4100
@@ -199,23 +203,17 @@ fn deposit_withdrawal_test() {
     let user3_deposit1 = Uint128::new(1000);
     let user3_expected_shares1 = Uint128::new(983);
 
-    // User3 deposits 1000 tokens -> mock this increase in the contract bank balance
-    mock_address_balance(
-        &mut deps,
-        inflow_contract_addr.as_ref(),
-        DEPOSIT_DENOM,
-        user1_deposit2 + user3_deposit1,
-    );
-
+    // User3 deposits 1000 tokens
     execute_deposit(
         &mut deps,
         &env,
+        &inflow_contract_addr,
         USER3,
-        &user3_address,
         &vault_shares_denom_str,
         user3_deposit1,
         user3_expected_shares1,
         user3_expected_shares1,
+        user1_deposit2 + user3_deposit1,
     );
 
     // Whitelisted address withdraws additional 3000 tokens
@@ -262,24 +260,1067 @@ fn deposit_withdrawal_test() {
     let user3_deposit2 = Uint128::new(1000);
     let user3_expected_shares2 = Uint128::new(956);
 
-    // User3 deposits 1000 tokens -> mock this increase in the contract bank balance
-    mock_address_balance(
-        &mut deps,
-        inflow_contract_addr.as_ref(),
-        DEPOSIT_DENOM,
-        user3_deposit2,
-    );
-
+    // User3 deposits 1000 tokens
     execute_deposit(
         &mut deps,
         &env,
+        &inflow_contract_addr,
         USER3,
-        &user3_address,
         &vault_shares_denom_str,
         user3_deposit2,
         user3_expected_shares2,
         user3_expected_shares1 + user3_expected_shares2,
+        user3_deposit2,
     );
+}
+
+#[test]
+fn withdrawal_test() {
+    let (mut deps, mut env) = (mock_dependencies(), mock_env());
+
+    let inflow_contract_addr = deps.api.addr_make(INFLOW);
+    let whitelist_addr = deps.api.addr_make(WHITELIST_ADDR);
+    let user1_addr = deps.api.addr_make(USER1);
+
+    env.contract.address = inflow_contract_addr.clone();
+
+    let instantiate_msg = get_default_instantiate_msg(DEPOSIT_DENOM, whitelist_addr.clone());
+
+    let info = get_message_info(&deps.api, "creator", &[]);
+    instantiate(deps.as_mut(), env.clone(), info, instantiate_msg).unwrap();
+
+    let vault_shares_denom_str: String =
+        format!("factory/{inflow_contract_addr}/hydro_inflow_uatom");
+
+    set_vault_shares_denom(&mut deps, vault_shares_denom_str.clone());
+
+    let user1_deposit1 = Uint128::new(1000);
+    let user1_expected_shares1 = Uint128::new(1000);
+
+    // Have User1 deposit 1000 tokens
+    execute_deposit(
+        &mut deps,
+        &env,
+        &inflow_contract_addr,
+        USER1,
+        &vault_shares_denom_str,
+        user1_deposit1,
+        user1_expected_shares1,
+        user1_expected_shares1,
+        user1_deposit1,
+    );
+
+    let user2_deposit1 = Uint128::new(2000);
+    let user2_expected_shares1 = Uint128::new(2000);
+
+    // Have User2 deposit 2000 tokens
+    execute_deposit(
+        &mut deps,
+        &env,
+        &inflow_contract_addr,
+        USER2,
+        &vault_shares_denom_str,
+        user2_deposit1,
+        user2_expected_shares1,
+        user2_expected_shares1,
+        user1_deposit1 + user2_deposit1,
+    );
+
+    assert_eq!(
+        query_available_for_deployment(&deps.as_ref(), &env).unwrap(),
+        user1_deposit1 + user2_deposit1
+    );
+
+    // User1 withdraws 500 shares. They should receive 500 deposit tokens.
+    let user1_withdraw_shares_1 = Uint128::new(500);
+    let user1_withdraw_tokens_1 = Uint128::new(500);
+
+    execute_withdraw(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        USER1,
+        &vault_shares_denom_str,
+        user1_withdraw_shares_1,
+        true,
+        user1_withdraw_tokens_1,
+        user1_expected_shares1 - user1_withdraw_shares_1,
+        Uint128::new(2500),
+    );
+
+    // User1 withdraws additional 500 shares. They should receive 500 deposit tokens.
+    execute_withdraw(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        USER1,
+        &vault_shares_denom_str,
+        user1_withdraw_shares_1,
+        true,
+        user1_withdraw_tokens_1,
+        Uint128::zero(),
+        Uint128::new(2000),
+    );
+
+    // User2 withdraws all 2000 shares at once. They should receive 2000 deposit tokens.
+    execute_withdraw(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        USER2,
+        &vault_shares_denom_str,
+        user2_expected_shares1,
+        true,
+        user2_deposit1,
+        Uint128::zero(),
+        Uint128::zero(),
+    );
+
+    verify_withdrawal_queue_info(&deps, Uint128::zero(), Uint128::zero(), Uint128::zero());
+
+    let user1_deposit2 = Uint128::new(15000);
+    let user1_expected_shares2 = Uint128::new(15000);
+
+    // Have User1 deposit 15000 tokens
+    execute_deposit(
+        &mut deps,
+        &env,
+        &inflow_contract_addr,
+        USER1,
+        &vault_shares_denom_str,
+        user1_deposit2,
+        user1_expected_shares2,
+        user1_expected_shares2,
+        user1_deposit2,
+    );
+
+    // Whitelisted address withdraws 15000 tokens for deployment
+    let withdrawal_amount = Uint128::new(15000);
+    execute_withdraw_for_deployment(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        WHITELIST_ADDR,
+        withdrawal_amount,
+        Uint128::zero(),
+    );
+
+    // User1 tries to withdraw 5000 shares. Contract doesn't have any tokens available,
+    // so they enter the withdrawal queue.
+    let user1_withdraw_shares_2 = Uint128::new(5000);
+    let user1_withdraw_tokens_2 = Uint128::new(5000);
+
+    execute_withdraw(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        USER1,
+        &vault_shares_denom_str,
+        user1_withdraw_shares_2,
+        false,
+        Uint128::zero(),
+        Uint128::new(10000),
+        Uint128::zero(),
+    );
+
+    verify_withdrawal_queue_info(
+        &deps,
+        user1_withdraw_shares_2,
+        user1_withdraw_tokens_2,
+        user1_withdraw_tokens_2,
+    );
+
+    assert_eq!(
+        query_available_for_deployment(&deps.as_ref(), &env).unwrap(),
+        Uint128::zero()
+    );
+
+    let user2_deposit2 = Uint128::new(4000);
+    let user2_shares2 = Uint128::new(4000);
+
+    // Have User2 deposit 4000 tokens
+    execute_deposit(
+        &mut deps,
+        &env,
+        &inflow_contract_addr,
+        USER2,
+        &vault_shares_denom_str,
+        user2_deposit2,
+        user2_shares2,
+        user2_shares2,
+        user2_deposit2,
+    );
+
+    // Amount available for deployment remains zero, since User1 has pending
+    // withdrawal worth 5000 tokens, and User2 deposited only 4000 tokens.
+    assert_eq!(
+        query_available_for_deployment(&deps.as_ref(), &env).unwrap(),
+        Uint128::zero()
+    );
+
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![(user1_withdraw_shares_2, user1_withdraw_tokens_2, false)],
+    );
+
+    let user2_deposit3 = Uint128::new(4000);
+    let user2_shares3 = Uint128::new(4000);
+
+    // Have User2 deposit additional 4000 tokens that will cover User1's
+    // pending withdrawal and leave 3000 tokens available for deployment.
+    execute_deposit(
+        &mut deps,
+        &env,
+        &inflow_contract_addr,
+        USER2,
+        &vault_shares_denom_str,
+        user2_deposit3,
+        user2_shares3,
+        user2_shares2 + user2_shares3,
+        user2_deposit2 + user2_deposit3,
+    );
+
+    // Verify that 3000 tokens are now available for deployment
+    assert_eq!(
+        query_available_for_deployment(&deps.as_ref(), &env).unwrap(),
+        Uint128::new(3000),
+    );
+
+    // User1 initiates withdrawal of 2000 shares. Since User2 deposited enough tokens to cover both
+    // User1's previous and new withdrawal request, the new request should be paid out immediately.
+    let user1_withdraw_shares_3 = Uint128::new(2000);
+    let user1_withdraw_tokens_3 = Uint128::new(2000);
+
+    execute_withdraw(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        USER1,
+        &vault_shares_denom_str,
+        user1_withdraw_shares_3,
+        true,
+        user1_withdraw_tokens_3,
+        Uint128::new(8000),
+        Uint128::new(6000),
+    );
+
+    // Verify that User1 has one (old) remaining withdrawal request in the queue
+    verify_withdrawal_queue_info(
+        &deps,
+        user1_withdraw_shares_2,
+        user1_withdraw_tokens_2,
+        user1_withdraw_tokens_2,
+    );
+
+    // Now the contract has 5000 tokens reserved for User1's withdrawal request,
+    // so the amount available for deployment is 1000 tokens.
+    assert_eq!(
+        query_available_for_deployment(&deps.as_ref(), &env).unwrap(),
+        Uint128::new(1000)
+    );
+}
+
+#[test]
+fn cancel_withdrawal_test() {
+    let (mut deps, mut env) = (mock_dependencies(), mock_env());
+
+    let inflow_contract_addr = deps.api.addr_make(INFLOW);
+    let whitelist_addr = deps.api.addr_make(WHITELIST_ADDR);
+    let user1_addr = deps.api.addr_make(USER1);
+    let user2_addr = deps.api.addr_make(USER2);
+
+    env.contract.address = inflow_contract_addr.clone();
+
+    let instantiate_msg = get_default_instantiate_msg(DEPOSIT_DENOM, whitelist_addr.clone());
+
+    let info = get_message_info(&deps.api, "creator", &[]);
+    instantiate(deps.as_mut(), env.clone(), info, instantiate_msg).unwrap();
+
+    let vault_shares_denom_str: String =
+        format!("factory/{inflow_contract_addr}/hydro_inflow_uatom");
+
+    set_vault_shares_denom(&mut deps, vault_shares_denom_str.clone());
+
+    let user1_deposit1 = Uint128::new(1000);
+    let user1_deposit_shares1 = Uint128::new(1000);
+
+    // Have User1 deposit 1000 tokens
+    execute_deposit(
+        &mut deps,
+        &env,
+        &inflow_contract_addr,
+        USER1,
+        &vault_shares_denom_str,
+        user1_deposit1,
+        user1_deposit_shares1,
+        user1_deposit_shares1,
+        user1_deposit1,
+    );
+
+    // Whitelisted address withdraws all tokens for deployment
+    execute_withdraw_for_deployment(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        WHITELIST_ADDR,
+        user1_deposit1,
+        Uint128::zero(),
+    );
+
+    // User1 tries to withdraw 1000 shares. Contract doesn't have any tokens available,
+    // so they enter the withdrawal queue (withdrawal request ID = 0).
+    execute_withdraw(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        USER1,
+        &vault_shares_denom_str,
+        user1_deposit_shares1,
+        false,
+        Uint128::zero(),
+        Uint128::zero(),
+        Uint128::zero(),
+    );
+
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![(user1_deposit_shares1, user1_deposit1, false)],
+    );
+
+    // User1 cancels their withdrawal request
+    execute_cancel_withdrawal(
+        &mut deps,
+        &env,
+        USER1,
+        vec![0u64],
+        &vault_shares_denom_str,
+        Some((user1_deposit_shares1, user1_deposit_shares1)),
+    );
+
+    // Verify that User1 has no remaining withdrawal requests
+    verify_user_withdrawal_requests(&deps, &user1_addr, vec![]);
+
+    // Have User2 deposit 500 tokens
+    let user2_deposit1 = Uint128::new(500);
+    let user2_deposit_shares1 = Uint128::new(500);
+
+    execute_deposit(
+        &mut deps,
+        &env,
+        &inflow_contract_addr,
+        USER2,
+        &vault_shares_denom_str,
+        user2_deposit1,
+        user2_deposit_shares1,
+        user2_deposit_shares1,
+        user2_deposit1,
+    );
+
+    // Whitelisted address withdraws all tokens for deployment
+    execute_withdraw_for_deployment(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        WHITELIST_ADDR,
+        user2_deposit1,
+        Uint128::zero(),
+    );
+
+    // Have User1 create 3 withdrawal requests with 200 shares each
+    let user1_withdraw_shares = Uint128::new(200);
+    let user1_withdraw_tokens = Uint128::new(200);
+    let mut user1_shares_after = user1_deposit_shares1;
+
+    for _ in 0..3 {
+        user1_shares_after = user1_shares_after
+            .checked_sub(user1_withdraw_shares)
+            .unwrap();
+
+        execute_withdraw(
+            &mut deps,
+            &env,
+            inflow_contract_addr.as_ref(),
+            USER1,
+            &vault_shares_denom_str,
+            user1_withdraw_shares,
+            false,
+            Uint128::zero(),
+            user1_shares_after,
+            Uint128::zero(),
+        );
+    }
+
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![
+            (user1_withdraw_shares, user1_withdraw_tokens, false),
+            (user1_withdraw_shares, user1_withdraw_tokens, false),
+            (user1_withdraw_shares, user1_withdraw_tokens, false),
+        ],
+    );
+
+    // Have User2 create 2 withdrawal requests with 250 shares each
+    let user2_withdraw_shares = Uint128::new(250);
+    let user2_withdraw_tokens = Uint128::new(250);
+    let mut user2_shares_after = user2_deposit_shares1;
+
+    for _ in 0..2 {
+        user2_shares_after = user2_shares_after
+            .checked_sub(user2_withdraw_shares)
+            .unwrap();
+
+        execute_withdraw(
+            &mut deps,
+            &env,
+            inflow_contract_addr.as_ref(),
+            USER2,
+            &vault_shares_denom_str,
+            user2_withdraw_shares,
+            false,
+            Uint128::zero(),
+            user2_shares_after,
+            Uint128::zero(),
+        );
+    }
+
+    verify_user_withdrawal_requests(
+        &deps,
+        &user2_addr,
+        vec![
+            (user2_withdraw_shares, user2_withdraw_tokens, false),
+            (user2_withdraw_shares, user2_withdraw_tokens, false),
+        ],
+    );
+
+    verify_withdrawal_queue_info(
+        &deps,
+        Uint128::new(1100),
+        Uint128::new(1100),
+        Uint128::new(1100),
+    );
+
+    // Mock as if the last funded withdrawal ID is 1
+    LAST_FUNDED_WITHDRAWAL_ID
+        .save(deps.as_mut().storage, &1u64)
+        .unwrap();
+
+    // User1 tries to cancel:
+    // - withdrawal request ID 0 (should be skipped, doesn't exist)
+    // - withdrawal request ID 1 (should be skipped, already funded)
+    // - withdrawal request ID 2 (should succeed, not funded yet)
+    // - withdrawal request ID 2 (should be filtered out, duplicate)
+    // - withdrawal request ID 3 (should succeed, not funded yet)
+    // - withdrawal request ID 4 (should be skipped, belongs to User2)
+    execute_cancel_withdrawal(
+        &mut deps,
+        &env,
+        USER1,
+        vec![0, 1, 2, 2, 3, 4],
+        &vault_shares_denom_str,
+        Some((
+            user1_withdraw_shares.checked_mul(Uint128::new(2)).unwrap(),
+            Uint128::new(600),
+        )),
+    );
+
+    // Verify that User1 has one remaining withdrawal request
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![(user1_withdraw_shares, user1_withdraw_tokens, false)],
+    );
+
+    // Verify that User2's withdrawal requests are unaffected
+    verify_user_withdrawal_requests(
+        &deps,
+        &user2_addr,
+        vec![
+            (user2_withdraw_shares, user2_withdraw_tokens, false),
+            (user2_withdraw_shares, user2_withdraw_tokens, false),
+        ],
+    );
+
+    // Verify that the withdrawal queue info is updated correctly
+    verify_withdrawal_queue_info(
+        &deps,
+        Uint128::new(700),
+        Uint128::new(700),
+        Uint128::new(700),
+    );
+}
+
+#[test]
+fn fulfill_pending_withdrawals_test() {
+    let (mut deps, mut env) = (mock_dependencies(), mock_env());
+
+    let inflow_contract_addr = deps.api.addr_make(INFLOW);
+    let whitelist_addr = deps.api.addr_make(WHITELIST_ADDR);
+    let user1_addr = deps.api.addr_make(USER1);
+    let user2_addr = deps.api.addr_make(USER2);
+
+    env.contract.address = inflow_contract_addr.clone();
+
+    let instantiate_msg = get_default_instantiate_msg(DEPOSIT_DENOM, whitelist_addr.clone());
+
+    let info = get_message_info(&deps.api, "creator", &[]);
+
+    instantiate(deps.as_mut(), env.clone(), info, instantiate_msg).unwrap();
+
+    let vault_shares_denom_str: String =
+        format!("factory/{inflow_contract_addr}/hydro_inflow_uatom");
+
+    set_vault_shares_denom(&mut deps, vault_shares_denom_str.clone());
+
+    // User1 deposits 10000 tokens
+    // User2 deposits 20000 tokens
+    let user1_deposit1 = Uint128::new(10000);
+    let user1_deposit_shares1 = Uint128::new(10000);
+    let user2_deposit1 = Uint128::new(20000);
+    let user2_deposit_shares1 = Uint128::new(20000);
+
+    let mut mock_inflow_balance_total = Uint128::zero();
+    for user_deposit in &[
+        (USER1, user1_deposit1, user1_deposit_shares1),
+        (USER2, user2_deposit1, user2_deposit_shares1),
+    ] {
+        mock_inflow_balance_total = mock_inflow_balance_total
+            .checked_add(user_deposit.1)
+            .unwrap();
+
+        execute_deposit(
+            &mut deps,
+            &env,
+            &inflow_contract_addr,
+            user_deposit.0,
+            &vault_shares_denom_str,
+            user_deposit.1,
+            user_deposit.2,
+            user_deposit.2,
+            mock_inflow_balance_total,
+        );
+    }
+
+    // Whitelisted address withdraws 30000 tokens for deployment
+    execute_withdraw_for_deployment(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        WHITELIST_ADDR,
+        user1_deposit1 + user2_deposit1,
+        Uint128::zero(),
+    );
+
+    // User1 requests withdrawal of 3000 shares (enters queue)
+    // User1 requests withdrawal of 4000 shares (enters queue)
+    // User2 requests withdrawal of 5000 shares (enters queue)
+    let user1_withdrawal_shares1 = Uint128::new(3000);
+    let user1_withdrawal_shares2 = Uint128::new(4000);
+    let user2_withdrawal_shares1 = Uint128::new(5000);
+
+    for user_withdrawal in &[
+        (
+            USER1,
+            user1_withdrawal_shares1,
+            user1_deposit_shares1 - user1_withdrawal_shares1,
+        ),
+        (
+            USER1,
+            user1_withdrawal_shares2,
+            user1_deposit_shares1 - user1_withdrawal_shares1 - user1_withdrawal_shares2,
+        ),
+        (
+            USER2,
+            user2_withdrawal_shares1,
+            user2_deposit_shares1 - user2_withdrawal_shares1,
+        ),
+    ] {
+        execute_withdraw(
+            &mut deps,
+            &env,
+            inflow_contract_addr.as_ref(),
+            user_withdrawal.0,
+            &vault_shares_denom_str,
+            user_withdrawal.1,
+            false,
+            Uint128::zero(),
+            user_withdrawal.2,
+            Uint128::zero(),
+        );
+    }
+
+    // Verify withdrawal requests for both users and withdrawal queue info
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![
+            (user1_withdrawal_shares1, Uint128::new(3000), false),
+            (user1_withdrawal_shares2, Uint128::new(4000), false),
+        ],
+    );
+    verify_user_withdrawal_requests(
+        &deps,
+        &user2_addr,
+        vec![(user2_withdrawal_shares1, Uint128::new(5000), false)],
+    );
+
+    verify_withdrawal_queue_info(
+        &deps,
+        user1_withdrawal_shares1 + user1_withdrawal_shares2 + user2_withdrawal_shares1,
+        Uint128::new(12000),
+        Uint128::new(12000),
+    );
+
+    // User3 deposits 3000 tokens
+    let user3_deposit1 = Uint128::new(3000);
+    let user3_deposit_shares1 = Uint128::new(3000);
+
+    execute_deposit(
+        &mut deps,
+        &env,
+        &inflow_contract_addr,
+        USER3,
+        &vault_shares_denom_str,
+        user3_deposit1,
+        user3_deposit_shares1,
+        user3_deposit_shares1,
+        user3_deposit1,
+    );
+
+    // Verify how much is needed to fulfill pending withdrawals (9000 tokens)
+    assert_eq!(
+        query_amount_to_fund_pending_withdrawals(&deps.as_ref(), &env).unwrap(),
+        Uint128::new(9000)
+    );
+
+    // Provide 9000 extra tokens to the contract for all pending withdrawals to be fulfilled
+    execute_return_from_deployment(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_str(),
+        WHITELIST_ADDR,
+        Uint128::new(9000),
+    );
+
+    // Execute fulfillment of pending withdrawals
+    execute_fulfill_pending_withdrawals(&mut deps, &env, WHITELIST_ADDR);
+
+    // Verify withdrawal requests for both users and withdrawal queue info
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![
+            (user1_withdrawal_shares1, Uint128::new(3000), true),
+            (user1_withdrawal_shares2, Uint128::new(4000), true),
+        ],
+    );
+    verify_user_withdrawal_requests(
+        &deps,
+        &user2_addr,
+        vec![(user2_withdrawal_shares1, Uint128::new(5000), true)],
+    );
+
+    verify_withdrawal_queue_info(
+        &deps,
+        user1_withdrawal_shares1 + user1_withdrawal_shares2 + user2_withdrawal_shares1,
+        Uint128::new(12000),
+        Uint128::zero(),
+    );
+
+    // User1 requests withdrawal of 3000 shares (enters queue)
+    // User2 requests withdrawal of 5000 shares (enters queue)
+    let user1_withdrawal_shares3 = Uint128::new(3000);
+    let user2_withdrawal_shares2 = Uint128::new(5000);
+
+    for user_withdrawal in &[
+        (USER1, user1_withdrawal_shares3, Uint128::zero()),
+        (
+            USER2,
+            user2_withdrawal_shares2,
+            user2_deposit_shares1 - user2_withdrawal_shares1 - user2_withdrawal_shares2,
+        ),
+    ] {
+        execute_withdraw(
+            &mut deps,
+            &env,
+            inflow_contract_addr.as_ref(),
+            user_withdrawal.0,
+            &vault_shares_denom_str,
+            user_withdrawal.1,
+            false,
+            Uint128::zero(),
+            user_withdrawal.2,
+            Uint128::zero(),
+        );
+    }
+
+    // Verify withdrawal requests for both users and withdrawal queue info
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![
+            (user1_withdrawal_shares1, Uint128::new(3000), true),
+            (user1_withdrawal_shares2, Uint128::new(4000), true),
+            (user1_withdrawal_shares3, Uint128::new(3000), false),
+        ],
+    );
+    verify_user_withdrawal_requests(
+        &deps,
+        &user2_addr,
+        vec![
+            (user2_withdrawal_shares1, Uint128::new(5000), true),
+            (user2_withdrawal_shares2, Uint128::new(5000), false),
+        ],
+    );
+
+    let total_withdrawal_queue_shares = user1_withdrawal_shares1
+        + user1_withdrawal_shares2
+        + user1_withdrawal_shares3
+        + user2_withdrawal_shares1
+        + user2_withdrawal_shares2;
+
+    verify_withdrawal_queue_info(
+        &deps,
+        total_withdrawal_queue_shares,
+        Uint128::new(20000),
+        Uint128::new(8000),
+    );
+
+    // Verify how much is needed to fulfill pending withdrawals (8000 tokens)
+    assert_eq!(
+        query_amount_to_fund_pending_withdrawals(&deps.as_ref(), &env).unwrap(),
+        Uint128::new(8000)
+    );
+
+    // Provide 7000 tokens (on top of existing 12000) to the contract for User1's pending withdrawal to be fulfilled
+    execute_return_from_deployment(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_str(),
+        WHITELIST_ADDR,
+        Uint128::new(7000),
+    );
+
+    // User1 executes claim_unbonded_withdrawals() for withdrawal request ID 1
+    execute_claim_unbodned_withdrawals(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        USER1,
+        vec![1],
+        None,
+        vec![(user1_addr.clone(), Uint128::new(4000))],
+        Uint128::new(15000),
+    );
+
+    // Execute fulfillment of pending withdrawals
+    execute_fulfill_pending_withdrawals(&mut deps, &env, WHITELIST_ADDR);
+
+    // Verify withdrawal requests for both users and withdrawal queue info
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![
+            (user1_withdrawal_shares1, Uint128::new(3000), true),
+            (user1_withdrawal_shares3, Uint128::new(3000), true),
+        ],
+    );
+
+    // 7000 tokens were provided, which isn't enough to fulfill User2's withdrawal request
+    // so the second withdrawal request will not be marked as funded
+    verify_user_withdrawal_requests(
+        &deps,
+        &user2_addr,
+        vec![
+            (user2_withdrawal_shares1, Uint128::new(5000), true),
+            (user2_withdrawal_shares2, Uint128::new(5000), false),
+        ],
+    );
+
+    let total_withdrawal_queue_shares = user1_withdrawal_shares1
+        + user1_withdrawal_shares3
+        + user2_withdrawal_shares1
+        + user2_withdrawal_shares2;
+
+    verify_withdrawal_queue_info(
+        &deps,
+        total_withdrawal_queue_shares,
+        Uint128::new(16000),
+        Uint128::new(5000),
+    );
+}
+
+#[test]
+fn claim_unbonded_withdrawals_test() {
+    let (mut deps, mut env) = (mock_dependencies(), mock_env());
+
+    let inflow_contract_addr = deps.api.addr_make(INFLOW);
+    let whitelist_addr = deps.api.addr_make(WHITELIST_ADDR);
+    let user1_addr = deps.api.addr_make(USER1);
+    let user2_addr = deps.api.addr_make(USER2);
+
+    env.contract.address = inflow_contract_addr.clone();
+
+    let instantiate_msg = get_default_instantiate_msg(DEPOSIT_DENOM, whitelist_addr.clone());
+
+    let info = get_message_info(&deps.api, "creator", &[]);
+
+    instantiate(deps.as_mut(), env.clone(), info, instantiate_msg).unwrap();
+
+    let vault_shares_denom_str: String =
+        format!("factory/{inflow_contract_addr}/hydro_inflow_uatom");
+
+    set_vault_shares_denom(&mut deps, vault_shares_denom_str.clone());
+
+    // User1 deposits 10000 tokens
+    // User2 deposits 20000 tokens
+    let user1_deposit1 = Uint128::new(10000);
+    let user1_deposit_shares1 = Uint128::new(10000);
+    let user2_deposit1 = Uint128::new(20000);
+    let user2_deposit_shares1 = Uint128::new(20000);
+
+    let mut mock_inflow_balance_total = Uint128::zero();
+    for user_deposit in &[
+        (USER1, user1_deposit1, user1_deposit_shares1),
+        (USER2, user2_deposit1, user2_deposit_shares1),
+    ] {
+        mock_inflow_balance_total = mock_inflow_balance_total
+            .checked_add(user_deposit.1)
+            .unwrap();
+
+        execute_deposit(
+            &mut deps,
+            &env,
+            &inflow_contract_addr,
+            user_deposit.0,
+            &vault_shares_denom_str,
+            user_deposit.1,
+            user_deposit.2,
+            user_deposit.2,
+            mock_inflow_balance_total,
+        );
+    }
+
+    // Whitelisted address withdraws 30000 tokens for deployment
+    execute_withdraw_for_deployment(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        WHITELIST_ADDR,
+        user1_deposit1 + user2_deposit1,
+        Uint128::zero(),
+    );
+
+    // User1 requests withdrawal of 1000 shares (enters queue)
+    // User1 requests withdrawal of 2000 shares (enters queue)
+    // User2 requests withdrawal of 2000 shares (enters queue)
+    // User2 requests withdrawal of 4000 shares (enters queue)
+    // User1 requests withdrawal of 3000 shares (enters queue)
+    // User2 requests withdrawal of 6000 shares (enters queue)
+    let user1_withdrawal_shares1 = Uint128::new(1000);
+    let user1_withdrawal_shares2 = Uint128::new(2000);
+    let user1_withdrawal_shares3 = Uint128::new(3000);
+    let user2_withdrawal_shares1 = Uint128::new(2000);
+    let user2_withdrawal_shares2 = Uint128::new(4000);
+    let user2_withdrawal_shares3 = Uint128::new(6000);
+
+    for user_withdrawal in &[
+        (
+            USER1,
+            user1_withdrawal_shares1,
+            user1_deposit_shares1 - user1_withdrawal_shares1,
+        ),
+        (
+            USER1,
+            user1_withdrawal_shares2,
+            user1_deposit_shares1 - user1_withdrawal_shares1 - user1_withdrawal_shares2,
+        ),
+        (
+            USER2,
+            user2_withdrawal_shares1,
+            user2_deposit_shares1 - user2_withdrawal_shares1,
+        ),
+        (
+            USER2,
+            user2_withdrawal_shares2,
+            user2_deposit_shares1 - user2_withdrawal_shares1 - user2_withdrawal_shares2,
+        ),
+        (
+            USER1,
+            user1_withdrawal_shares3,
+            user1_deposit_shares1
+                - user1_withdrawal_shares1
+                - user1_withdrawal_shares2
+                - user1_withdrawal_shares3,
+        ),
+        (
+            USER2,
+            user2_withdrawal_shares3,
+            user2_deposit_shares1
+                - user2_withdrawal_shares1
+                - user2_withdrawal_shares2
+                - user2_withdrawal_shares3,
+        ),
+    ] {
+        execute_withdraw(
+            &mut deps,
+            &env,
+            inflow_contract_addr.as_ref(),
+            user_withdrawal.0,
+            &vault_shares_denom_str,
+            user_withdrawal.1,
+            false,
+            Uint128::zero(),
+            user_withdrawal.2,
+            Uint128::zero(),
+        );
+    }
+
+    // Verify withdrawal requests for both users and withdrawal queue info
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![
+            (user1_withdrawal_shares1, Uint128::new(1000), false), // ID = 0
+            (user1_withdrawal_shares2, Uint128::new(2000), false), // ID = 1
+            (user1_withdrawal_shares3, Uint128::new(3000), false), // ID = 4
+        ],
+    );
+    verify_user_withdrawal_requests(
+        &deps,
+        &user2_addr,
+        vec![
+            (user2_withdrawal_shares1, Uint128::new(2000), false), // ID = 2
+            (user2_withdrawal_shares2, Uint128::new(4000), false), // ID = 3
+            (user2_withdrawal_shares3, Uint128::new(6000), false), // ID = 5
+        ],
+    );
+
+    verify_withdrawal_queue_info(
+        &deps,
+        user1_withdrawal_shares1
+            + user1_withdrawal_shares2
+            + user1_withdrawal_shares3
+            + user2_withdrawal_shares1
+            + user2_withdrawal_shares2
+            + user2_withdrawal_shares3,
+        Uint128::new(18000),
+        Uint128::new(18000),
+    );
+
+    // Provide 9000 tokens to the contract to fulfill first 4 withdrawal requests
+    execute_return_from_deployment(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_str(),
+        WHITELIST_ADDR,
+        Uint128::new(9000),
+    );
+
+    // Execute fulfillment of 4 pending withdrawals
+    execute_fulfill_pending_withdrawals(&mut deps, &env, WHITELIST_ADDR);
+
+    // Verify withdrawal requests for both users and withdrawal queue info
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![
+            (user1_withdrawal_shares1, Uint128::new(1000), true), // ID = 0
+            (user1_withdrawal_shares2, Uint128::new(2000), true), // ID = 1
+            (user1_withdrawal_shares3, Uint128::new(3000), false), // ID = 4
+        ],
+    );
+    verify_user_withdrawal_requests(
+        &deps,
+        &user2_addr,
+        vec![
+            (user2_withdrawal_shares1, Uint128::new(2000), true), // ID = 2
+            (user2_withdrawal_shares2, Uint128::new(4000), true), // ID = 3
+            (user2_withdrawal_shares3, Uint128::new(6000), false), // ID = 5
+        ],
+    );
+
+    verify_withdrawal_queue_info(
+        &deps,
+        user1_withdrawal_shares1
+            + user1_withdrawal_shares2
+            + user1_withdrawal_shares3
+            + user2_withdrawal_shares1
+            + user2_withdrawal_shares2
+            + user2_withdrawal_shares3,
+        Uint128::new(18000),
+        Uint128::new(9000),
+    );
+
+    // Try to claim invalid withdrawals (e.g. non-existing IDs, or the ones that weren't funded, duplicates)
+    // and verify that the correct error is returned.
+    execute_claim_unbodned_withdrawals(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        USER1,
+        vec![4, 5, 4, 9],
+        Some("must provide at least one valid withdrawal id"),
+        vec![],
+        Uint128::zero(),
+    );
+
+    // Execute claim for withdrawal requests 0, 1 and 2, but also provide duplicate IDs and non-funded IDs
+    // and verify that those are filtered out properly
+    execute_claim_unbodned_withdrawals(
+        &mut deps,
+        &env,
+        inflow_contract_addr.as_ref(),
+        USER1,
+        vec![0, 1, 2, 0, 2, 4, 5],
+        None,
+        vec![
+            (user1_addr.clone(), Uint128::new(3000)),
+            (user2_addr.clone(), Uint128::new(2000)),
+        ],
+        Uint128::zero(),
+    );
+
+    // Verify withdrawal requests for both users and withdrawal queue info
+    verify_user_withdrawal_requests(
+        &deps,
+        &user1_addr,
+        vec![
+            (user1_withdrawal_shares3, Uint128::new(3000), false), // ID = 4
+        ],
+    );
+    verify_user_withdrawal_requests(
+        &deps,
+        &user2_addr,
+        vec![
+            (user2_withdrawal_shares2, Uint128::new(4000), true), // ID = 3
+            (user2_withdrawal_shares3, Uint128::new(6000), false), // ID = 5
+        ],
+    );
+
+    verify_withdrawal_queue_info(
+        &deps,
+        user1_withdrawal_shares3 + user2_withdrawal_shares2 + user2_withdrawal_shares3,
+        Uint128::new(13000),
+        Uint128::new(9000),
+    );
+
+    // Verify payout history for both users
+    verify_users_payouts_history(
+        &deps,
+        vec![
+            (
+                user1_addr.clone(),
+                vec![(Uint128::new(3000), Uint128::new(3000))],
+            ),
+            (
+                user2_addr.clone(),
+                vec![(Uint128::new(2000), Uint128::new(2000))],
+            ),
+        ],
+    )
 }
 
 #[test]
@@ -293,20 +1334,7 @@ fn whitelist_add_remove_test() {
 
     env.contract.address = inflow_contract_addr.clone();
 
-    let instantiate_msg = InstantiateMsg {
-        deposit_denom: DEPOSIT_DENOM.to_string(),
-        whitelist: vec![user1_address.to_string()],
-        subdenom: "hydro_inflow_uatom".to_string(),
-        token_metadata: DenomMetadata {
-            display: "hydro_inflow_atom".to_string(),
-            exponent: 6,
-            name: "Hydro Inflow ATOM".to_string(),
-            description: "Hydro Inflow ATOM".to_string(),
-            symbol: "hydro_inflow_atom".to_string(),
-            uri: None,
-            uri_hash: None,
-        },
-    };
+    let instantiate_msg = get_default_instantiate_msg(DEPOSIT_DENOM, user1_address.clone());
 
     let info = get_message_info(&deps.api, "creator", &[]);
     instantiate(deps.as_mut(), env.clone(), info, instantiate_msg).unwrap();
@@ -400,58 +1428,6 @@ fn whitelist_add_remove_test() {
         .contains("cannot remove last outstanding whitelisted address"));
 }
 
-#[allow(clippy::too_many_arguments)]
-fn execute_deposit(
-    deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
-    env: &Env,
-    user_str: &str,
-    user_address: &Addr,
-    vault_shares_denom_str: &String,
-    deposit_amount: Uint128,
-    expected_shares_minted: Uint128,
-    expected_shares_total: Uint128,
-) {
-    let info = get_message_info(
-        &deps.api,
-        user_str,
-        &[Coin {
-            denom: DEPOSIT_DENOM.to_string(),
-            amount: deposit_amount,
-        }],
-    );
-
-    let deposit_res = execute(
-        deps.as_mut(),
-        env.clone(),
-        info.clone(),
-        ExecuteMsg::Deposit {},
-    )
-    .unwrap();
-
-    // Verify mint message for vault shares tokens
-    let mint_msg = &deposit_res.messages[0].msg;
-    match mint_msg {
-        CosmosMsg::Custom(NeutronMsg::MintTokens {
-            denom,
-            amount,
-            mint_to_address,
-        }) => {
-            assert_eq!(denom, vault_shares_denom_str);
-            assert_eq!(amount, expected_shares_minted);
-            assert_eq!(mint_to_address, user_address.as_ref());
-        }
-        _ => panic!("Expected MintTokens message"),
-    }
-
-    // Mock that the user received vault shares tokens on its bank balance
-    mock_address_balance(
-        deps,
-        user_address.as_ref(),
-        vault_shares_denom_str,
-        expected_shares_total,
-    );
-}
-
 #[test]
 fn submit_deployed_amount_test() {
     let (mut deps, env) = (mock_dependencies(), mock_env());
@@ -459,20 +1435,7 @@ fn submit_deployed_amount_test() {
     let whitelist_addr = deps.api.addr_make(WHITELIST_ADDR);
     let user1_address = deps.api.addr_make(USER1);
 
-    let instantiate_msg = InstantiateMsg {
-        deposit_denom: DEPOSIT_DENOM.to_string(),
-        whitelist: vec![whitelist_addr.to_string()],
-        subdenom: "hydro_inflow_uatom".to_string(),
-        token_metadata: DenomMetadata {
-            display: "hydro_inflow_atom".to_string(),
-            exponent: 6,
-            name: "Hydro Inflow ATOM".to_string(),
-            description: "Hydro Inflow ATOM".to_string(),
-            symbol: "hydro_inflow_atom".to_string(),
-            uri: None,
-            uri_hash: None,
-        },
-    };
+    let instantiate_msg = get_default_instantiate_msg(DEPOSIT_DENOM, whitelist_addr);
 
     let info = get_message_info(&deps.api, "creator", &[]);
     instantiate(deps.as_mut(), env.clone(), info, instantiate_msg).unwrap();
@@ -525,20 +1488,7 @@ fn reporting_balance_queries_test() {
 
     env.contract.address = inflow_contract_addr.clone();
 
-    let instantiate_msg = InstantiateMsg {
-        deposit_denom: DEPOSIT_DENOM.to_string(),
-        whitelist: vec![whitelist_addr.to_string()],
-        subdenom: "hydro_inflow_uatom".to_string(),
-        token_metadata: DenomMetadata {
-            display: "hydro_inflow_atom".to_string(),
-            exponent: 6,
-            name: "Hydro Inflow ATOM".to_string(),
-            description: "Hydro Inflow ATOM".to_string(),
-            symbol: "hydro_inflow_atom".to_string(),
-            uri: None,
-            uri_hash: None,
-        },
-    };
+    let instantiate_msg = get_default_instantiate_msg(DEPOSIT_DENOM, whitelist_addr);
 
     let info = get_message_info(&deps.api, "creator", &[]);
     instantiate(deps.as_mut(), env.clone(), info, instantiate_msg).unwrap();
@@ -546,18 +1496,9 @@ fn reporting_balance_queries_test() {
     let vault_shares_denom_str: String =
         format!("factory/{inflow_contract_addr}/hydro_inflow_uatom");
 
-    VAULT_SHARES_DENOM
-        .save(deps.as_mut().storage, &vault_shares_denom_str.clone())
-        .unwrap();
+    set_vault_shares_denom(&mut deps, vault_shares_denom_str.clone());
 
     let deposit_amount = Uint128::from(500_000u128);
-
-    mock_address_balance(
-        &mut deps,
-        inflow_contract_addr.as_ref(),
-        DEPOSIT_DENOM,
-        deposit_amount,
-    );
 
     let user1_deposit1 = Uint128::new(500_000);
     let user1_expected_shares1 = Uint128::new(500_000);
@@ -565,12 +1506,13 @@ fn reporting_balance_queries_test() {
     execute_deposit(
         &mut deps,
         &env,
+        &inflow_contract_addr,
         USER1,
-        &user1_address,
         &vault_shares_denom_str,
         user1_deposit1,
         user1_expected_shares1,
         user1_expected_shares1,
+        deposit_amount,
     );
 
     let deployed_amount = Uint128::new(1000);
@@ -619,4 +1561,426 @@ fn reporting_balance_queries_test() {
 
     let eq_value: Uint128 = from_json(query_res.unwrap()).unwrap();
     assert_eq!(eq_value, deployed_amount + deposit_amount);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_deposit(
+    deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    env: &Env,
+    inflow_contract_addr: &Addr,
+    user_str: &str,
+    vault_shares_denom_str: &String,
+    deposit_amount: Uint128,
+    expected_user_shares_minted: Uint128,
+    mock_user_shares_total: Uint128,
+    mock_inflow_deposit_tokens_total: Uint128,
+) {
+    // Mock that the Inflow contract has deposit tokens on its bank balance,
+    // since in reallity this happens before execute() is called.
+    mock_address_balance(
+        deps,
+        inflow_contract_addr.as_ref(),
+        DEPOSIT_DENOM,
+        mock_inflow_deposit_tokens_total,
+    );
+
+    let info = get_message_info(
+        &deps.api,
+        user_str,
+        &[Coin {
+            denom: DEPOSIT_DENOM.to_string(),
+            amount: deposit_amount,
+        }],
+    );
+
+    let user_address = info.sender.clone();
+    let deposit_res = execute(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        ExecuteMsg::Deposit {},
+    )
+    .unwrap();
+
+    // Verify mint message for vault shares tokens
+    let mint_msg = &deposit_res.messages[0].msg;
+    match mint_msg {
+        CosmosMsg::Custom(NeutronMsg::MintTokens {
+            denom,
+            amount,
+            mint_to_address,
+        }) => {
+            assert_eq!(denom, vault_shares_denom_str);
+            assert_eq!(amount, expected_user_shares_minted);
+            assert_eq!(mint_to_address, user_address.as_ref());
+        }
+        _ => panic!("Expected MintTokens message"),
+    }
+
+    // Mock that the user received vault shares tokens on its bank balance
+    mock_address_balance(
+        deps,
+        user_address.as_ref(),
+        vault_shares_denom_str,
+        mock_user_shares_total,
+    );
+}
+
+fn execute_withdraw_for_deployment(
+    deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    env: &Env,
+    inflow_contract_addr: &str,
+    whitelisted_user_str: &str,
+    amount_to_withdraw: Uint128,
+    mock_inflow_balance_after: Uint128,
+) {
+    let info = get_message_info(&deps.api, whitelisted_user_str, &[]);
+
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        ExecuteMsg::WithdrawForDeployment {
+            amount: amount_to_withdraw,
+        },
+    )
+    .unwrap();
+
+    mock_address_balance(
+        deps,
+        inflow_contract_addr,
+        DEPOSIT_DENOM,
+        mock_inflow_balance_after,
+    );
+}
+
+fn execute_return_from_deployment(
+    deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    env: &Env,
+    inflow_contract_addr: &str,
+    whitelisted_user_str: &str,
+    amount_to_return: Uint128,
+) {
+    let info = get_message_info(&deps.api, whitelisted_user_str, &[]);
+
+    let current_contract_balance: Uint128 = from_json::<BalanceResponse>(
+        deps.querier
+            .bank
+            .query(&BankQuery::Balance {
+                address: inflow_contract_addr.to_owned(),
+                denom: DEPOSIT_DENOM.to_owned(),
+            })
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap()
+    .amount
+    .amount;
+
+    mock_address_balance(
+        deps,
+        inflow_contract_addr,
+        DEPOSIT_DENOM,
+        current_contract_balance + amount_to_return,
+    );
+
+    let deployed_amount_current = DEPLOYED_AMOUNT.load(&deps.storage).unwrap();
+    let deployed_amount_updated = deployed_amount_current - amount_to_return;
+
+    // Update info on the amount currently deployed by the whiteslited address.
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        ExecuteMsg::SubmitDeployedAmount {
+            amount: deployed_amount_updated,
+        },
+    )
+    .unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+fn execute_withdraw(
+    deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    env: &Env,
+    inflow_contract_addr: &str,
+    user_str: &str,
+    vault_shares_denom_str: &String,
+    withdraw_shares_amount: Uint128,
+    should_receive_deposit_tokens: bool,
+    expected_tokens_received: Uint128,
+    total_user_shares_after: Uint128,
+    contract_deposit_tokens_after: Uint128,
+) {
+    let info = get_message_info(
+        &deps.api,
+        user_str,
+        &[Coin {
+            denom: vault_shares_denom_str.to_string(),
+            amount: withdraw_shares_amount,
+        }],
+    );
+
+    let user_address = info.sender.clone();
+    let withdraw_res = execute(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        ExecuteMsg::Withraw {},
+    )
+    .unwrap();
+
+    if should_receive_deposit_tokens {
+        // Verify bank send message to receive deposit tokens
+        let bank_send_msg = &withdraw_res.messages[0].msg;
+        match bank_send_msg {
+            CosmosMsg::Bank(BankMsg::Send { to_address, amount }) => {
+                assert_eq!(to_address, user_address.as_ref());
+                assert_eq!(amount[0].denom, DEPOSIT_DENOM);
+                assert_eq!(amount[0].amount, expected_tokens_received);
+            }
+            _ => panic!("Expected BankSend message"),
+        }
+
+        // Verify burn message for vault shares tokens
+        let burn_msg = &withdraw_res.messages[1].msg;
+        match burn_msg {
+            CosmosMsg::Custom(NeutronMsg::BurnTokens {
+                denom,
+                amount,
+                burn_from_address: _,
+            }) => {
+                assert_eq!(denom, vault_shares_denom_str);
+                assert_eq!(amount, withdraw_shares_amount);
+            }
+            _ => panic!("Expected MintTokens message"),
+        }
+
+        // Update Inflow contract deposit tokens balance
+        mock_address_balance(
+            deps,
+            inflow_contract_addr,
+            DEPOSIT_DENOM,
+            contract_deposit_tokens_after,
+        );
+    }
+
+    // Update user's vault shares tokens balance
+    mock_address_balance(
+        deps,
+        user_address.as_ref(),
+        vault_shares_denom_str,
+        total_user_shares_after,
+    );
+}
+
+type CancelWithdrawalExpectedResult = (
+    Uint128, // expected_vault_shares_received
+    Uint128, // mock_user_shares_after
+);
+
+fn execute_cancel_withdrawal(
+    deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    env: &Env,
+    user_str: &str,
+    withdrawal_ids: Vec<u64>,
+    vault_shares_denom_str: &String,
+    expected_result: Option<CancelWithdrawalExpectedResult>,
+) {
+    let info = get_message_info(&deps.api, user_str, &[]);
+
+    let user_address = info.sender.clone();
+    let cancel_withdrawal_res = execute(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        ExecuteMsg::CancelWithrawal { withdrawal_ids },
+    )
+    .unwrap();
+
+    if let Some(expected_result) = expected_result {
+        // Verify mint message for vault shares tokens
+        let mint_msg = &cancel_withdrawal_res.messages[0].msg;
+        match mint_msg {
+            CosmosMsg::Custom(NeutronMsg::MintTokens {
+                denom,
+                amount,
+                mint_to_address,
+            }) => {
+                assert_eq!(denom, vault_shares_denom_str);
+                assert_eq!(amount, expected_result.0);
+                assert_eq!(mint_to_address, user_address.as_ref());
+            }
+            _ => panic!("Expected MintTokens message"),
+        }
+
+        // Update user's vault shares tokens balance
+        mock_address_balance(
+            deps,
+            user_address.as_ref(),
+            vault_shares_denom_str,
+            expected_result.1,
+        );
+    }
+}
+
+type ClaimUnbondedWithdrawalExpectedResult = (
+    Addr,    // withdrawer address
+    Uint128, // expected_tokens_received
+);
+
+#[allow(clippy::too_many_arguments)]
+fn execute_claim_unbodned_withdrawals(
+    deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    env: &Env,
+    inflow_contract_addr: &str,
+    sender_str: &str,
+    withdrawal_ids: Vec<u64>,
+    expected_error: Option<&str>,
+    expected_results: Vec<ClaimUnbondedWithdrawalExpectedResult>,
+    mock_inflow_contract_total_tokens: Uint128,
+) {
+    let info = get_message_info(&deps.api, sender_str, &[]);
+    let claim_unbodned_withdrawals_res = execute(
+        deps.as_mut(),
+        env.clone(),
+        info.clone(),
+        ExecuteMsg::ClaimUnbondedWithdrawals { withdrawal_ids },
+    );
+
+    if let Some(err) = expected_error {
+        assert!(claim_unbodned_withdrawals_res
+            .unwrap_err()
+            .to_string()
+            .contains(err));
+        return;
+    }
+
+    let claim_unbodned_withdrawals_res = claim_unbodned_withdrawals_res.unwrap();
+
+    assert_eq!(
+        claim_unbodned_withdrawals_res.messages.len(),
+        expected_results.len()
+    );
+
+    let expected_results: HashMap<String, Uint128> = expected_results
+        .into_iter()
+        .map(|expected_res| (expected_res.0.to_string(), expected_res.1))
+        .collect();
+
+    for i in 0..claim_unbodned_withdrawals_res.messages.len() {
+        let bank_msg = claim_unbodned_withdrawals_res.messages[i].msg.clone();
+        match bank_msg {
+            CosmosMsg::Bank(BankMsg::Send { to_address, amount }) => {
+                // Successful get verifies that the recipient is expected
+                let expected_amount = expected_results.get(&to_address).unwrap();
+                assert_eq!(amount[0].amount, expected_amount);
+                assert_eq!(amount[0].denom, DEPOSIT_DENOM);
+            }
+            _ => panic!("Expected BankMsg::Send"),
+        }
+
+        mock_address_balance(
+            deps,
+            inflow_contract_addr,
+            DEPOSIT_DENOM,
+            mock_inflow_contract_total_tokens,
+        );
+    }
+}
+
+fn execute_fulfill_pending_withdrawals(
+    deps: &mut OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    env: &Env,
+    user_str: &str,
+) {
+    let info = get_message_info(&deps.api, user_str, &[]);
+
+    execute(
+        deps.as_mut(),
+        env.clone(),
+        info,
+        ExecuteMsg::FulfillPendingWithdrawals { limit: 100 },
+    )
+    .unwrap();
+}
+
+fn verify_withdrawal_queue_info(
+    deps: &OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    expected_total_shares_burned: Uint128,
+    expected_total_withdrawal_amount: Uint128,
+    expected_non_funded_withdrawal_amount: Uint128,
+) {
+    let queue_info = query_withdrawal_queue_info(&deps.as_ref()).unwrap();
+
+    assert_eq!(
+        queue_info.info.total_shares_burned,
+        expected_total_shares_burned
+    );
+    assert_eq!(
+        queue_info.info.total_withdrawal_amount,
+        expected_total_withdrawal_amount
+    );
+    assert_eq!(
+        queue_info.info.non_funded_withdrawal_amount,
+        expected_non_funded_withdrawal_amount
+    );
+}
+
+type ExpectedWithdrawalRequest = (
+    Uint128, // shares_burned
+    Uint128, // amount_to_receive
+    bool,    // is_funded
+);
+
+fn verify_user_withdrawal_requests(
+    deps: &OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    user_address: &Addr,
+    expected_withdrawal_requests: Vec<ExpectedWithdrawalRequest>,
+) {
+    let user_withdrawals =
+        query_user_withdrawal_requests(&deps.as_ref(), user_address.to_string(), 0, 100).unwrap();
+
+    assert_eq!(
+        user_withdrawals.withdrawals.len(),
+        expected_withdrawal_requests.len()
+    );
+
+    for (i, expected) in expected_withdrawal_requests.iter().enumerate() {
+        assert_eq!(user_withdrawals.withdrawals[i].shares_burned, expected.0);
+        assert_eq!(
+            user_withdrawals.withdrawals[i].amount_to_receive,
+            expected.1
+        );
+        assert_eq!(user_withdrawals.withdrawals[i].is_funded, expected.2);
+    }
+}
+
+type ExpectedPayoutHistory = (
+    Addr,                    // recipient
+    Vec<(Uint128, Uint128)>, // (shares_burned, amount_received)
+);
+
+fn verify_users_payouts_history(
+    deps: &OwnedDeps<MemoryStorage, MockApi, MockQuerier, NeutronQuery>,
+    expected_payouts_history: Vec<ExpectedPayoutHistory>,
+) {
+    for expected_user_payouts in expected_payouts_history {
+        let user_payouts = query_user_payouts_history(
+            &deps.as_ref(),
+            expected_user_payouts.0.to_string(),
+            0,
+            100,
+            Order::Ascending,
+        )
+        .unwrap()
+        .payouts;
+
+        assert_eq!(user_payouts.len(), expected_user_payouts.1.len());
+
+        for (i, expected_payout) in expected_user_payouts.1.iter().enumerate() {
+            assert_eq!(user_payouts[i].vault_shares_burned, expected_payout.0);
+            assert_eq!(user_payouts[i].amount_received, expected_payout.1);
+        }
+    }
 }


### PR DESCRIPTION
[Recompile the contracts and regenerate the schema before merging]

## Description

This PR adds 4 new execute() variants, as well as several new queries to the Inflow contract, in order to implement the funds withdrawal functionality. New actions:
- `Withraw {}` - Users initiate withdrawals with this action. If there are enough funds to cover all pending withdrawals plus the new one, users will receive the deposit tokens immediately. Otherwise, they enter the withdrawal queue.
- `CancelWithrawal { withdrawal_ids: Vec<u64> }` - Users can cancel their existing withdrawal request that are still in the queue, until the moment the funds for the given request have been provided.
- `FulfillPendingWithdrawals { limit: u64 }` - Permissionless action. Iterates over withdrawal requests queue, checks the smart contract balance, and marks the requests as funded if there is enough funds in the contract to pay them out to the users.
- `ClaimUnbondedWithdrawals { withdrawal_ids: Vec<u64> }` - Permissionless action. Iterates over the provided withdrawal request ids, checks if they have been funded and performs the actual payouts to those users that initiated those withdrawals.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Targeted the correct branch
* [x] Included the necessary unit tests
* [ ] Added/adjusted the necessary [interchain tests](./test/interchain/)
* [ ] Added necessary migration code for all stores that were adjusted or added
* [ ] Added a changelog entry in `.changelog`
* [ ] Compiled the contracts by using `make compile` and included content of the *artifacts* directory into the PR
* [ ] Regenerated front-end schema by using `make schema` and included generated files into the PR
* [ ] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary
* [x] Confirmed all CI checks have passed
