### PR TITLE
Switched to a different Neutron node in relaying tools

### DIFF
--- a/tools/deployment/config_mainnet.json
+++ b/tools/deployment/config_mainnet.json
@@ -1,7 +1,7 @@
 {
     "chain_id": "neutron-1",
-    "neutron_rpc_node": "https://neutron-rpc.publicnode.com:443",
-    "neutron_api_node": "https://neutron-rest.publicnode.com",
+    "neutron_rpc_node": "https://rpc-lb.neutron.org:443",
+    "neutron_api_node": "https://rest-lb.neutron.org",
     "hub_rpc_node": "https://cosmos-rpc.publicnode.com:443",
     "hub_api_node": "https://api.cosmos.nodestake.org",
     "tx_sender_wallet": "submitter",

--- a/tools/relaying.sh
+++ b/tools/relaying.sh
@@ -13,8 +13,8 @@ export NUM_VALIDATORS_TO_ADD=$NUM_OF_VALIDATORS
 
 # populate the config for the ICQ relayer and the ICQ query creation
 export NEUTRON_CHAIN_ID="neutron-1"
-export RELAYER_NEUTRON_CHAIN_RPC_ADDR=https://neutron-rpc.publicnode.com:443
-export RELAYER_NEUTRON_CHAIN_REST_ADDR=https://neutron-rest.publicnode.com
+export RELAYER_NEUTRON_CHAIN_RPC_ADDR=https://rpc-lb.neutron.org:443    # alternative: https://neutron-rpc.publicnode.com:443
+export RELAYER_NEUTRON_CHAIN_REST_ADDR=https://rest-lb.neutron.org      # alternative: https://neutron-rest.publicnode.com
 export RELAYER_NEUTRON_CHAIN_HOME_DIR=$HOME/.neutrond
 export RELAYER_NEUTRON_CHAIN_SIGN_KEY_NAME=submitter
 export RELAYER_NEUTRON_CHAIN_KEYRING_BACKEND=test


### PR DESCRIPTION
## Description

ICQ relaying stopped working for us at some point. Pinged Neutron team, they are still investigating the issue, but they provided us a different node to use, and it actually helped. This PR replaces old node with a new one in our relaying scripts.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Targeted the correct branch
* [ ] Included the necessary unit tests
* [ ] Added/adjusted the necessary [interchain tests](./test/interchain/)
* [ ] Added necessary migration code for all stores that were adjusted or added
* [ ] Added a changelog entry in `.changelog`
* [ ] Compiled the contracts by using `make compile` and included content of the *artifacts* directory into the PR
* [ ] Regenerated front-end schema by using `make schema` and included generated files into the PR
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary
* [ ] Confirmed all CI checks have passed
