### PR TITLE
Implement cosmwasm_std 3.0 compatibility feature

### DIFF
--- a/contracts/inflow/proxy/Cargo.toml
+++ b/contracts/inflow/proxy/Cargo.toml
@@ -8,6 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 library = []
+cosmwasm_compat = ["interface/cosmwasm_compat"]
 
 [dependencies]
 cosmwasm-std = { workspace = true }

--- a/contracts/inflow/proxy/src/contract.rs
+++ b/contracts/inflow/proxy/src/contract.rs
@@ -3,6 +3,8 @@ use cosmwasm_std::{
     DepsMut, Env, MessageInfo, Reply, Response, StdError, StdResult, SubMsg, SubMsgResult, WasmMsg,
 };
 use cw2::set_contract_version;
+#[cfg(feature = "cosmwasm_compat")]
+use interface::compat::StdErrExt;
 
 use interface::{
     inflow::{

--- a/contracts/inflow/proxy/src/error.rs
+++ b/contracts/inflow/proxy/src/error.rs
@@ -1,7 +1,9 @@
 use cosmwasm_std::StdError;
+#[cfg(feature = "cosmwasm_compat")]
+use interface::compat::StdErrExt;
 use thiserror::Error;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum ContractError {
     #[error("{0}")]
     Std(#[from] StdError),

--- a/contracts/inflow/proxy/src/testing.rs
+++ b/contracts/inflow/proxy/src/testing.rs
@@ -10,6 +10,8 @@ use cosmwasm_std::{
     testing::{mock_dependencies, mock_env, MockApi},
     Addr, BankMsg, Coin, CosmosMsg, Uint128, WasmMsg,
 };
+#[cfg(feature = "cosmwasm_compat")]
+use interface::compat::Uint256TestingExt;
 use interface::inflow::{Config as InflowConfig, ExecuteMsg as InflowExecuteMsg};
 use test_utils::{
     testing_mocks::{setup_contract_smart_query_mock, MockWasmQuerier},

--- a/contracts/inflow/proxy/src/testing_mocks.rs
+++ b/contracts/inflow/proxy/src/testing_mocks.rs
@@ -1,4 +1,6 @@
 use cosmwasm_std::{from_json, to_json_binary, Addr, Binary, StdError, StdResult};
+#[cfg(feature = "cosmwasm_compat")]
+use interface::compat::StdErrExt;
 use interface::{
     inflow::{
         Config as InflowConfig, ConfigResponse as InflowConfigResponse, QueryMsg as InflowQueryMsg,

--- a/packages/interface/Cargo.toml
+++ b/packages/interface/Cargo.toml
@@ -3,6 +3,9 @@ name = "interface"
 version = { workspace = true }
 edition = { workspace = true }
 
+[features]
+cosmwasm_compat = []
+
 [dependencies]
 cosmwasm-std = { workspace = true }
 cosmwasm-schema = { workspace = true }

--- a/packages/interface/src/compat.rs
+++ b/packages/interface/src/compat.rs
@@ -1,0 +1,24 @@
+use cosmwasm_std::{StdError, Uint128, Uint256};
+
+pub trait StdErrExt {
+    fn generic_err<T: Into<String>>(msg: T) -> StdError {
+        StdError::msg(msg.into())
+    }
+
+    // https://github.com/CosmWasm/cosmwasm/blob/33191cb067be86d3b5733e21b4f0fc61343f0661/packages/std/src/errors/std_error.rs#L51C14-L51C30
+    fn not_found<T: Into<String>>(msg: T) -> StdError {
+        StdError::msg(format!("{} not found", msg.into()))
+    }
+}
+
+impl StdErrExt for StdError {}
+
+pub trait Uint256TestingExt {
+    fn u128(&self) -> u128;
+}
+
+impl Uint256TestingExt for Uint256 {
+    fn u128(&self) -> u128 {
+        Uint128::try_from(*self).unwrap().u128()
+    }
+}

--- a/packages/interface/src/lib.rs
+++ b/packages/interface/src/lib.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "cosmwasm_compat")]
+pub mod compat;
 pub mod drop_core;
 pub mod drop_puppeteer;
 pub mod gatekeeper;

--- a/packages/interface/src/utils.rs
+++ b/packages/interface/src/utils.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "cosmwasm_compat")]
+use crate::compat::StdErrExt;
 use cosmwasm_std::{Reply, StdError, StdResult};
 
 // SubMsg ID is used so that we can differentiate submessages sent by the smart contract when the Wasm SDK module


### PR DESCRIPTION
I noticed that hydro is dependant on Neutron which uses cosmwasm_std 2.0 and wasn't updated in a while.
That makes some of the projects incompatible because of a few breaking changes in cosmwasm_std 3.0. 

Adding that simple comatibility interface solves that issue though.