### PR TITLE
Add PR workflow section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,3 +174,26 @@ After modifying contract messages:
 - Contracts target `wasm32-unknown-unknown`
 - Release builds use aggressive optimization (LTO, single codegen unit)
 - The workspace version (currently 3.6.6) is synchronized across all contracts
+
+## Before Creating a PR
+
+Run these commands before committing:
+
+```bash
+# Format code (required)
+make fmt
+
+# Run linter
+make clippy
+
+# Run unit tests
+make test-unit
+
+# Regenerate schemas if you modified contract messages
+make schema
+
+# Compile contracts (requires Docker)
+make compile
+```
+
+Add artifacts, schemas, and a changelog entry to your PR.


### PR DESCRIPTION
## Description

Add a "Before Creating a PR" section to CLAUDE.md that documents the commands to run before committing:

- `make fmt` (required) - Format code
- `make clippy` - Run linter
- `make test-unit` - Run unit tests
- `make schema` - Regenerate schemas if contract messages were modified
- `make compile` - Compile contracts (requires Docker)

Also notes to add artifacts, schemas, and changelog entries to PRs.

---

### Author Checklist

* [x] Targeted the correct branch
* [x] Included the necessary unit tests - N/A: Documentation only
* [x] Added/adjusted the necessary interchain tests - N/A: Documentation only
* [x] Added necessary migration code - N/A: Documentation only
* [x] Added a changelog entry - N/A: Documentation only
* [x] Compiled the contracts - N/A: Documentation only
* [x] Regenerated front-end schema - N/A: Documentation only
* [x] Updated the relevant documentation - Yes, this PR
* [x] Reviewed "Files changed"
* [ ] Confirmed all CI checks have passed - Awaiting CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)