### PR TITLE
Add pagination to AllAvailableConversionFunds query

### DIFF
--- a/.changelog/unreleased/features/374-all-available-conversion-funds-query.md
+++ b/.changelog/unreleased/features/374-all-available-conversion-funds-query.md
@@ -1,2 +1,2 @@
-- Added `AllAvailableConversionFunds` query that returns all conversion fund denoms with their amounts and base token equivalents for a given round
+- Added `AllAvailableConversionFunds` query that returns all conversion fund denoms with their amounts and base token equivalents for a given round, with pagination support via `start_after` and `limit` parameters
   ([\#374](https://github.com/informalsystems/hydro/pull/374))

--- a/contracts/hydro/schema/hydro.json
+++ b/contracts/hydro/schema/hydro.json
@@ -2974,7 +2974,7 @@
         "additionalProperties": false
       },
       {
-        "description": "Returns all available conversion funds with their amounts and base token equivalents for a given round. The total_base_token_equivalent is the sum of all funds converted to base token using their ratios.",
+        "description": "Returns all available conversion funds with their amounts and base token equivalents for a given round. The total_base_token_equivalent is the sum of all funds converted to base token using their ratios. Supports pagination via start_after (denom to start after) and limit (max items to return).",
         "type": "object",
         "required": [
           "all_available_conversion_funds"
@@ -2986,10 +2986,24 @@
               "round_id"
             ],
             "properties": {
+              "limit": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
               "round_id": {
                 "type": "integer",
                 "format": "uint64",
                 "minimum": 0.0
+              },
+              "start_after": {
+                "type": [
+                  "string",
+                  "null"
+                ]
               }
             },
             "additionalProperties": false
@@ -3040,16 +3054,21 @@
       "type": "object",
       "required": [
         "funds",
+        "has_more",
         "round_id",
         "total_base_token_equivalent"
       ],
       "properties": {
         "funds": {
-          "description": "List of all conversion funds with their base token equivalents",
+          "description": "List of conversion funds with their base token equivalents (paginated)",
           "type": "array",
           "items": {
             "$ref": "#/definitions/ConversionFundInfo"
           }
+        },
+        "has_more": {
+          "description": "Indicates if there are more funds after this page. Use the last denom as start_after for the next page.",
+          "type": "boolean"
         },
         "round_id": {
           "description": "The round ID used for ratio calculations",
@@ -3058,7 +3077,7 @@
           "minimum": 0.0
         },
         "total_base_token_equivalent": {
-          "description": "Total base token equivalent across all denoms (sum of all base_token_equivalent values)",
+          "description": "Total base token equivalent for the funds returned in this page (sum of base_token_equivalent values)",
           "allOf": [
             {
               "$ref": "#/definitions/Uint128"

--- a/contracts/hydro/schema/raw/query.json
+++ b/contracts/hydro/schema/raw/query.json
@@ -1224,7 +1224,7 @@
       "additionalProperties": false
     },
     {
-      "description": "Returns all available conversion funds with their amounts and base token equivalents for a given round. The total_base_token_equivalent is the sum of all funds converted to base token using their ratios.",
+      "description": "Returns all available conversion funds with their amounts and base token equivalents for a given round. The total_base_token_equivalent is the sum of all funds converted to base token using their ratios. Supports pagination via start_after (denom to start after) and limit (max items to return).",
       "type": "object",
       "required": [
         "all_available_conversion_funds"
@@ -1236,10 +1236,24 @@
             "round_id"
           ],
           "properties": {
+            "limit": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
             "round_id": {
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
+            },
+            "start_after": {
+              "type": [
+                "string",
+                "null"
+              ]
             }
           },
           "additionalProperties": false

--- a/contracts/hydro/schema/raw/response_to_all_available_conversion_funds.json
+++ b/contracts/hydro/schema/raw/response_to_all_available_conversion_funds.json
@@ -4,16 +4,21 @@
   "type": "object",
   "required": [
     "funds",
+    "has_more",
     "round_id",
     "total_base_token_equivalent"
   ],
   "properties": {
     "funds": {
-      "description": "List of all conversion funds with their base token equivalents",
+      "description": "List of conversion funds with their base token equivalents (paginated)",
       "type": "array",
       "items": {
         "$ref": "#/definitions/ConversionFundInfo"
       }
+    },
+    "has_more": {
+      "description": "Indicates if there are more funds after this page. Use the last denom as start_after for the next page.",
+      "type": "boolean"
     },
     "round_id": {
       "description": "The round ID used for ratio calculations",
@@ -22,7 +27,7 @@
       "minimum": 0.0
     },
     "total_base_token_equivalent": {
-      "description": "Total base token equivalent across all denoms (sum of all base_token_equivalent values)",
+      "description": "Total base token equivalent for the funds returned in this page (sum of base_token_equivalent values)",
       "allOf": [
         {
           "$ref": "#/definitions/Uint128"

--- a/contracts/hydro/src/query.rs
+++ b/contracts/hydro/src/query.rs
@@ -249,8 +249,13 @@ pub enum QueryMsg {
 
     /// Returns all available conversion funds with their amounts and base token equivalents for a given round.
     /// The total_base_token_equivalent is the sum of all funds converted to base token using their ratios.
+    /// Supports pagination via start_after (denom to start after) and limit (max items to return).
     #[returns(AllAvailableConversionFundsResponse)]
-    AllAvailableConversionFunds { round_id: u64 },
+    AllAvailableConversionFunds {
+        round_id: u64,
+        start_after: Option<String>,
+        limit: Option<u32>,
+    },
 
     /// Given a lock id and a resulting token denom, returns the number of tokens of a resulting denom
     /// that a given lockup would hold after conversion.
@@ -596,8 +601,10 @@ pub struct ConversionFundInfo {
 pub struct AllAvailableConversionFundsResponse {
     /// The round ID used for ratio calculations
     pub round_id: u64,
-    /// List of all conversion funds with their base token equivalents
+    /// List of conversion funds with their base token equivalents (paginated)
     pub funds: Vec<ConversionFundInfo>,
-    /// Total base token equivalent across all denoms (sum of all base_token_equivalent values)
+    /// Total base token equivalent for the funds returned in this page (sum of base_token_equivalent values)
     pub total_base_token_equivalent: Uint128,
+    /// Indicates if there are more funds after this page. Use the last denom as start_after for the next page.
+    pub has_more: bool,
 }

--- a/ts_types/HydroBase.client.ts
+++ b/ts_types/HydroBase.client.ts
@@ -289,9 +289,13 @@ export interface HydroBaseReadOnlyInterface {
     tokenDenom: string;
   }) => Promise<Uint128>;
   allAvailableConversionFunds: ({
-    roundId
+    limit,
+    roundId,
+    startAfter
   }: {
+    limit?: number;
     roundId: number;
+    startAfter?: string;
   }) => Promise<AllAvailableConversionFundsResponse>;
   convertedTokenNum: ({
     lockId,
@@ -934,13 +938,19 @@ export class HydroBaseQueryClient implements HydroBaseReadOnlyInterface {
     });
   };
   allAvailableConversionFunds = async ({
-    roundId
+    limit,
+    roundId,
+    startAfter
   }: {
+    limit?: number;
     roundId: number;
+    startAfter?: string;
   }): Promise<AllAvailableConversionFundsResponse> => {
     return this.client.queryContractSmart(this.contractAddress, {
       all_available_conversion_funds: {
-        round_id: roundId
+        limit,
+        round_id: roundId,
+        start_after: startAfter
       }
     });
   };

--- a/ts_types/HydroBase.types.ts
+++ b/ts_types/HydroBase.types.ts
@@ -489,7 +489,9 @@ export type QueryMsg = {
   };
 } | {
   all_available_conversion_funds: {
+    limit?: number | null;
     round_id: number;
+    start_after?: string | null;
   };
 } | {
   converted_token_num: {
@@ -500,6 +502,7 @@ export type QueryMsg = {
 };
 export interface AllAvailableConversionFundsResponse {
   funds: ConversionFundInfo[];
+  has_more: boolean;
   round_id: number;
   total_base_token_equivalent: Uint128;
 }


### PR DESCRIPTION
## Summary

- Adds `start_after` and `limit` pagination parameters to the `AllAvailableConversionFunds` query to prevent potential gas exhaustion when many conversion fund denominations accumulate
- Adds `has_more` field to response to indicate if more results exist beyond the current page
- Default limit is 30, maximum limit is 100
- Uses cursor-based pagination for efficient iteration

## Changes

- **query.rs**: Added `start_after: Option<String>` and `limit: Option<u32>` to query, `has_more: bool` to response
- **contract.rs**: Updated implementation with pagination logic using `Bound::exclusive`
- **testing_lockup_conversion.rs**: Added comprehensive pagination tests
- **schemas & ts_types**: Regenerated

## Test plan

- [x] Existing tests updated and passing
- [x] New pagination test covers: limit, start_after cursor, end detection, default limit
- [x] `make clippy` passes
- [x] `make fmt` passes
- [x] `make test-unit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)