### PR TITLE
Add artifact compilation instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,7 +171,9 @@ After modifying contract messages:
 ## Artifact Compilation
 After modifying any contract code (including queries, but excluding tests), before committing:
 1. Run `make compile` to regenerate artifacts
-2. Artifacts are auto-generated in `artifacts`, including their checksums
+2. Artifacts are auto-generated in `artifacts`, including their checksums.
+
+This is important to ensure that the binaries are consistent with the code.
 
 Note that for `make compile` to work, Docker has to be running.
 If `make compile` fails with a message about Docker not running, ask the user to start it.


### PR DESCRIPTION
quick one here for Claude. It already knows to compile as part of its workflow, but it thought if it just modified queries it doesn't have to recompile, so giving it some more detail